### PR TITLE
Add global loading overlay

### DIFF
--- a/frontend/src/core/storage.js
+++ b/frontend/src/core/storage.js
@@ -1,5 +1,5 @@
 // 📁 frontend/src/storage.js
-import { showToast } from "./ui.js";
+import { showToast, redirectWithLoading } from "./ui.js";
 const MOVIE_CACHE_PREFIX = "movieCache::";
 const FOLDER_CACHE_PREFIX = "folderCache::";
 
@@ -24,7 +24,7 @@ export function getMovieCacheKey(sourceKey, path) {
  */
 export function changeRootFolder() {
   localStorage.removeItem("rootFolder");
-  window.location.href = "/select.html";
+  redirectWithLoading("/select.html");
 }
 
 /**
@@ -35,14 +35,14 @@ export function requireRootFolder() {
 
   if (!root) {
     showToast("⚠️ Chưa chọn thư mục gốc, vui lòng chọn lại!");
-    window.location.href = "/select.html";
+    redirectWithLoading("/select.html");
   }
 }
 export function requireSourceKey() {
   const source = getSourceKey();
   if (!source) {
     showToast("⚠️ Chưa chọn nguồn dữ liệu, vui lòng chọn lại!");
-    window.location.href = "/home.html";
+    redirectWithLoading("/home.html");
   }
 }
 

--- a/frontend/src/core/ui.js
+++ b/frontend/src/core/ui.js
@@ -57,9 +57,9 @@ export async function filterManga() {
 
         // Nếu đang trong reader.html thì redirect thủ công
         if (window.location.pathname.includes("reader.html")) {
-          window.location.href = `/manga/index.html?path=${encodeURIComponent(
+          redirectWithLoading(`/manga/index.html?path=${encodeURIComponent(
             f.path
-          )}`;
+          )}`);
         } else {
           window.loadFolder?.(f.path);
         }
@@ -119,13 +119,13 @@ export async function filterMovie() {
       item.onclick = () => {
         dropdown.classList.add("hidden");
         if (f.type === "video" || f.type === "file") {
-          window.location.href = `/movie/player.html?file=${encodeURIComponent(
-            f.path
-          )}&key=${sourceKey}`;
+          redirectWithLoading(
+            `/movie/player.html?file=${encodeURIComponent(f.path)}&key=${sourceKey}`
+          );
         } else {
-          window.location.href = `/movie/index.html?path=${encodeURIComponent(
-            f.path
-          )}`;
+          redirectWithLoading(
+            `/movie/index.html?path=${encodeURIComponent(f.path)}`
+          );
         }
       };
 
@@ -416,7 +416,7 @@ sidebar.appendChild(
           count++;
         }
       });
-      window.location.href = "/home.html"; // ✅ Quay lại chọn root
+      redirectWithLoading("/home.html"); // ✅ Quay lại chọn root
       showToast(`✅ Đã xoá ${count} cache folder`);
     }))
   );
@@ -534,7 +534,7 @@ export function setupMovieSidebar() {
   sidebar.appendChild(
     createSidebarButton("🎬 Đổi Movie Folder", () => {
       localStorage.removeItem("rootFolder");
-      window.location.href = "/home.html";
+      redirectWithLoading("/home.html");
     })
   );
 
@@ -654,7 +654,7 @@ export function setupMusicSidebar() {
   sidebar.appendChild(
     createSidebarButton("🎼 Đổi Music Folder", () => {
       localStorage.removeItem("rootFolder");
-      window.location.href = "/home.html";
+      redirectWithLoading("/home.html");
     })
   );
 
@@ -796,13 +796,13 @@ export async function filterMusic() {
       item.onclick = () => {
         dropdown.classList.add("hidden");
         if (isAudio) {
-          window.location.href = `/music/player.html?file=${encodeURIComponent(
-            f.path
-          )}`;
+          redirectWithLoading(
+            `/music/player.html?file=${encodeURIComponent(f.path)}`
+          );
         } else {
-          window.location.href = `/music/index.html?path=${encodeURIComponent(
-            f.path
-          )}`;
+          redirectWithLoading(
+            `/music/index.html?path=${encodeURIComponent(f.path)}`
+          );
         }
       };
 
@@ -938,4 +938,25 @@ export function hideOverlay() {
 export function showOverlay() {
   const overlay = document.getElementById("loading-overlay");
   if (overlay) overlay.classList.remove("hidden");
+}
+
+// 🌀 Hiển thị loading khi gọi fetch hoặc chuyển trang
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (...args) => {
+    const overlay = document.getElementById("loading-overlay");
+    overlay?.classList.remove("hidden");
+    return originalFetch(...args).finally(() => overlay?.classList.add("hidden"));
+  };
+
+  window.addEventListener("beforeunload", () => {
+    const overlay = document.getElementById("loading-overlay");
+    overlay?.classList.remove("hidden");
+  });
+}
+
+export function redirectWithLoading(url) {
+  const overlay = document.getElementById("loading-overlay");
+  overlay?.classList.remove("hidden");
+  window.location.href = url;
 }

--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -1,4 +1,5 @@
 // /src/pages/home.js
+import { redirectWithLoading } from "/src/core/ui.js";
 
 function renderSourceList(listId, keys, type) {
   const container = document.getElementById(listId);
@@ -12,13 +13,11 @@ function renderSourceList(listId, keys, type) {
     btn.onclick = async () => {
       localStorage.setItem("sourceKey", key);
 
-      // Hiện overlay loading
-      const overlay = document.getElementById("loading-overlay");
-      overlay?.classList.remove("hidden");
+
 
       try {
         if (type === "manga") {
-          window.location.href = "/select.html";
+          redirectWithLoading("/select.html");
         } else if (type === "movie") {
           const resp = await fetch(`/api/movie/movie-folder-empty?key=${key}`);
           const data = await resp.json();
@@ -31,8 +30,7 @@ function renderSourceList(listId, keys, type) {
             });
           }
           // Chuyển trang sau khi mọi thứ xong
-          window.location.href = "/movie/index.html";
-          overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
+          redirectWithLoading("/movie/index.html");
         } else if (type === "music") {
           const resp = await fetch(`/api/music/music-folder?key=${key}`);
           const data = await resp.json();
@@ -44,14 +42,12 @@ function renderSourceList(listId, keys, type) {
             });
           }
 
-          window.location.href = "/music/index.html";
-          overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
+          redirectWithLoading("/music/index.html");
         }
       } catch (err) {
         // Có thể hiện toast lỗi nếu muốn
         console.error("❌ Lỗi check/scan DB:", err);
         alert("Lỗi khi load dữ liệu!"); // hoặc showToast nếu đã dùng ở home
-        overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
       }
     };
     container.appendChild(btn);
@@ -59,10 +55,7 @@ function renderSourceList(listId, keys, type) {
 }
 
 // Đảm bảo 2 script đã load lên window trước khi render (script inline .js nên yên tâm)
-// Đảm bảo overlay luôn ẩn khi vào lại trang Home
 window.addEventListener("DOMContentLoaded", () => {
-  const overlay = document.getElementById("loading-overlay");
-  overlay?.classList.add("hidden");
   // ... gọi renderSourceList như cũ
   renderSourceList("manga-list", window.mangaKeys || [], "manga");
   renderSourceList("movie-list", window.movieKeys || [], "movie");


### PR DESCRIPTION
## Summary
- show overlay automatically when fetching and navigating
- add redirectWithLoading helper and use in storage and home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5941571483288ff78a16c8a48d06