### PR TITLE
Add thumbnail management in music and movie player 

### DIFF
--- a/backend/api/movie/set-thumbnail.js
+++ b/backend/api/movie/set-thumbnail.js
@@ -1,0 +1,48 @@
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+const router = express.Router();
+const { getRootPath } = require("../../utils/config");
+const { getMovieDB } = require("../../utils/db");
+
+function findThumbFile(baseDir, baseName) {
+  const exts = [".jpg", ".png", ".jpeg", ".webp", ".avif"]; 
+  for (const ext of exts) {
+    const file = path.join(baseDir, baseName + ext);
+    if (fs.existsSync(file)) return { file, ext };
+  }
+  return null;
+}
+
+router.post("/folder-thumbnail", (req, res) => {
+  const { key, folderPath, srcPath } = req.body;
+  if (!key || !folderPath || !srcPath)
+    return res.status(400).json({ error: "Missing data" });
+  try {
+    const root = getRootPath(key);
+    const srcAbs = path.join(root, srcPath);
+    const srcThumbDir = path.join(path.dirname(srcAbs), ".thumbnail");
+    const baseName = path.basename(srcPath, path.extname(srcPath));
+    const found = findThumbFile(srcThumbDir, baseName);
+    if (!found) return res.status(404).json({ error: "Thumbnail not found" });
+
+    const folderAbs = path.join(root, folderPath);
+    const folderName = path.basename(folderAbs);
+    const destDir = path.join(folderAbs, ".thumbnail");
+    if (!fs.existsSync(destDir)) fs.mkdirSync(destDir);
+    const dest = path.join(destDir, folderName + found.ext);
+    fs.copyFileSync(found.file, dest);
+
+    const db = getMovieDB(key);
+    db.prepare(
+      `UPDATE folders SET thumbnail = ?, updatedAt = ? WHERE path = ?`
+    ).run(path.posix.join(".thumbnail", folderName + found.ext), Date.now(), folderPath);
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error("movie folder-thumbnail error", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+module.exports = router;

--- a/backend/api/music/playlist.js
+++ b/backend/api/music/playlist.js
@@ -16,7 +16,7 @@ router.get("/playlists", (req, res) => {
   const rows = db
     .prepare(
       `
-    SELECT id, name, description FROM playlists
+    SELECT id, name, description, thumbnail FROM playlists
     ORDER BY updatedAt DESC
   `
     )
@@ -36,7 +36,7 @@ router.get("/playlist/:id", (req, res) => {
 
   // Lấy thông tin tên playlist
   const playlist = db
-    .prepare(`SELECT id, name, description FROM playlists WHERE id = ?`)
+    .prepare(`SELECT id, name, description, thumbnail FROM playlists WHERE id = ?`)
     .get(id);
 
   // Lấy danh sách track

--- a/backend/api/music/playlist.js
+++ b/backend/api/music/playlist.js
@@ -66,6 +66,7 @@ router.get("/playlist/:id", (req, res) => {
     id: playlist.id,
     name: playlist.name,
     description: playlist.description,
+    thumbnail: playlist.thumbnail || null,
     tracks: items,
   });
 });

--- a/backend/api/music/set-thumbnail.js
+++ b/backend/api/music/set-thumbnail.js
@@ -1,0 +1,78 @@
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+const router = express.Router();
+const { getRootPath } = require("../../utils/config");
+const { getMusicDB } = require("../../utils/db");
+
+function findThumbFile(baseDir, baseName) {
+  const exts = [".jpg", ".png", ".jpeg", ".webp", ".avif"];
+  for (const ext of exts) {
+    const file = path.join(baseDir, baseName + ext);
+    if (fs.existsSync(file)) return { file, ext };
+  }
+  return null;
+}
+
+router.post("/folder-thumbnail", (req, res) => {
+  const { key, folderPath, srcPath } = req.body;
+  if (!key || !folderPath || !srcPath)
+    return res.status(400).json({ error: "Missing data" });
+  try {
+    const root = getRootPath(key);
+    const srcAbs = path.join(root, srcPath);
+    const srcThumbDir = path.join(path.dirname(srcAbs), ".thumbnail");
+    const baseName = path.basename(srcPath, path.extname(srcPath));
+    const found = findThumbFile(srcThumbDir, baseName);
+    if (!found) return res.status(404).json({ error: "Thumbnail not found" });
+
+    const folderAbs = path.join(root, folderPath);
+    const folderName = path.basename(folderAbs);
+    const destDir = path.join(folderAbs, ".thumbnail");
+    if (!fs.existsSync(destDir)) fs.mkdirSync(destDir);
+    const dest = path.join(destDir, folderName + found.ext);
+    fs.copyFileSync(found.file, dest);
+
+    const db = getMusicDB(key);
+    db.prepare(
+      `UPDATE folders SET thumbnail = ?, updatedAt = ? WHERE path = ?`
+    ).run(path.posix.join(".thumbnail", folderName + found.ext), Date.now(), folderPath);
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error("folder-thumbnail error", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+router.post("/playlist-thumbnail", (req, res) => {
+  const { key, playlistId, srcPath } = req.body;
+  if (!key || !playlistId || !srcPath)
+    return res.status(400).json({ error: "Missing data" });
+  try {
+    const root = getRootPath(key);
+    const srcAbs = path.join(root, srcPath);
+    const srcThumbDir = path.join(path.dirname(srcAbs), ".thumbnail");
+    const baseName = path.basename(srcPath, path.extname(srcPath));
+    const found = findThumbFile(srcThumbDir, baseName);
+    if (!found) return res.status(404).json({ error: "Thumbnail not found" });
+
+    const destDir = path.join(root, "playlist_thumbs");
+    if (!fs.existsSync(destDir)) fs.mkdirSync(destDir);
+    const dest = path.join(destDir, String(playlistId) + found.ext);
+    fs.copyFileSync(found.file, dest);
+    const rel = path.posix.join("playlist_thumbs", String(playlistId) + found.ext);
+
+    const db = getMusicDB(key);
+    db.prepare(
+      `UPDATE playlists SET thumbnail = ?, updatedAt = ? WHERE id = ?`
+    ).run(rel, Date.now(), playlistId);
+
+    res.json({ success: true, thumbnail: rel });
+  } catch (err) {
+    console.error("playlist-thumbnail error", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -135,3 +135,4 @@ app.use("/api/music", require("./api/music/playlist"));
 app.use("/api/music", require("./api/music/music-meta"));
 app.use("/api/music", require("./api/music/reset-music-db"));
 app.use("/api/music", require("./api/music/extract-thumbnail"));
+app.use("/api/music", require("./api/music/set-thumbnail"));

--- a/backend/server.js
+++ b/backend/server.js
@@ -125,6 +125,7 @@ app.use("/api/movie", require("./api/movie/reset-movie-db"));
 app.use("/api/movie", require("./api/movie/video-cache"));
 app.use("/api/movie", require("./api/movie/favorite-movie"));
 app.use("/api/movie", require("./api/movie/extract-movie-thumbnail"));
+app.use("/api/movie", require("./api/movie/set-thumbnail"));
 
 //
 app.use("/api/music", require("./api/music/scan-music"));

--- a/backend/utils/db.js
+++ b/backend/utils/db.js
@@ -146,6 +146,7 @@ function getMusicDB(dbkey) {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
       description TEXT,
+      thumbnail TEXT,
       createdAt INTEGER,
       updatedAt INTEGER
     );
@@ -158,6 +159,14 @@ function getMusicDB(dbkey) {
       PRIMARY KEY (playlistId, songPath)
     );
   `);
+
+  const cols = db
+    .prepare("PRAGMA table_info(playlists)")
+    .all()
+    .map((c) => c.name);
+  if (!cols.includes("thumbnail")) {
+    db.exec("ALTER TABLE playlists ADD COLUMN thumbnail TEXT");
+  }
 
   dbMap[dbkey] = db;
   return db;

--- a/frontend/public/movie/player.html
+++ b/frontend/public/movie/player.html
@@ -20,6 +20,7 @@
       </div>
       <div class="header-right">
         <button class="icon-button" id="fav-btn">🤍</button>
+        <button class="icon-button" id="set-thumb-btn">🖼️</button>
         <button class="icon-button" id="searchToggle">🔍</button>
       </div>
     </header>

--- a/frontend/src/pages/movie/player.js
+++ b/frontend/src/pages/movie/player.js
@@ -24,6 +24,7 @@ const file = urlParams.get("file");
 const sourceKey = getSourceKey();
 const videoEl = document.getElementById("video-player");
 const favBtn = document.getElementById("fav-btn");
+const setThumbBtn = document.getElementById("set-thumb-btn");
 if (!file || !sourceKey) {
   showToast("❌ Thiếu file hoặc sourceKey");
   throw new Error("Missing file or sourceKey");
@@ -91,6 +92,25 @@ favBtn.onclick = async () => {
   } catch (err) {
     console.error("❌ Failed to toggle favorite:", err);
     showToast("❌ Lỗi khi toggle yêu thích");
+  }
+};
+
+if (setThumbBtn) setThumbBtn.onclick = async () => {
+  try {
+    await fetch("/api/movie/extract-movie-thumbnail", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: sourceKey, path: file }),
+    });
+    await fetch("/api/movie/folder-thumbnail", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: sourceKey, folderPath, srcPath: file }),
+    });
+    showToast("✅ Đã đặt thumbnail");
+  } catch (err) {
+    console.error("set-thumb error", err);
+    showToast("❌ Lỗi đặt thumbnail");
   }
 };
 

--- a/frontend/src/pages/movie/player.js
+++ b/frontend/src/pages/movie/player.js
@@ -97,7 +97,7 @@ favBtn.onclick = async () => {
 
 if (setThumbBtn) setThumbBtn.onclick = async () => {
   try {
-    await fetch("/api/movie/extract-movie-thumbnail", {
+    await fetch("/api/movie/extract-thumbnail", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: sourceKey, path: file }),

--- a/frontend/src/pages/music/index.js
+++ b/frontend/src/pages/music/index.js
@@ -316,6 +316,9 @@ async function loadPlaylistSlider() {
 
     const withThumbs = await Promise.all(
       playlists.map(async (p) => {
+        if (p.thumbnail) {
+          return { ...p, path: p.id.toString(), thumbnail: buildThumbnailUrl({ thumbnail: p.thumbnail, path: "" }, "music"), isPlaylist: true, type: "folder" };
+        }
         try {
           const r = await fetch(`/api/music/playlist/${p.id}?key=${key}`);
           const detail = await r.json();

--- a/frontend/src/pages/music/player.js
+++ b/frontend/src/pages/music/player.js
@@ -65,6 +65,7 @@ function renderNowPlayingInfo(track) {
           body: JSON.stringify({ key: sourceKey, playlistId, srcPath: track.path }),
         });
         showToast("✅ Đã đặt thumbnail cho playlist");
+        loadPlaylistSlider();
       } else {
         await fetch("/api/music/folder-thumbnail", {
           method: "POST",

--- a/frontend/src/styles/pages/music/player.css
+++ b/frontend/src/styles/pages/music/player.css
@@ -388,6 +388,23 @@ body, html {
   background: #169447;
 }
 
+#btn-add-thumb {
+  background: #a259ec;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+  font-size: 18px;
+  cursor: pointer;
+  margin-left: 6px;
+  vertical-align: middle;
+  transition: background 0.2s;
+}
+#btn-add-thumb:hover {
+  background: #873fcb;
+}
+
 /* Collapsible playlist */
 .playlist-collapse {
   margin: 16px 0;


### PR DESCRIPTION
## Summary
- allow storing playlist thumbnails in database
- support updating folder or playlist thumbnail via new API
- expose new API route and database column updates
- show 'Add thumbnail' button in music player UI
- use playlist thumbnails if available when loading playlists
- style button for setting thumbnail

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d02faf960832898d7c99ceda11f9d