### PR TITLE
Add otherName field for manga folders

### DIFF
--- a/backend/api/manga/folder-cache.js
+++ b/backend/api/manga/folder-cache.js
@@ -87,9 +87,9 @@ router.get("/folder-cache", async (req, res) => {
       }
       const rows = db.prepare(`
         SELECT name, path, thumbnail, isFavorite FROM folders
-        WHERE root = ? AND name LIKE ?
+        WHERE root = ? AND (name LIKE ? OR otherName LIKE ?)
         ORDER BY name ASC LIMIT 50
-      `).all(root, `%${q}%`);
+      `).all(root, `%${q}%`, `%${q}%`);
       return res.json(rows);
     }
     // Nếu mode không hợp lệ

--- a/backend/utils/db.js
+++ b/backend/utils/db.js
@@ -36,6 +36,7 @@ function getDB(dbkey) {
       lastModified INTEGER,
       imageCount INTEGER DEFAULT 0,
       chapterCount INTEGER DEFAULT 0,
+      otherName TEXT,
       type TEXT DEFAULT 'folder',
       createdAt INTEGER,
       updatedAt INTEGER,
@@ -58,6 +59,11 @@ function getDB(dbkey) {
       thumbnail TEXT
     );
   `);
+  // ➕ đảm bảo có cột otherName khi nâng cấp DB cũ
+  const cols = db.prepare(`PRAGMA table_info(folders)`).all().map((c) => c.name);
+  if (!cols.includes("otherName")) {
+    db.prepare(`ALTER TABLE folders ADD COLUMN otherName TEXT`).run();
+  }
 
   dbMap[dbkey] = db;
   return db;


### PR DESCRIPTION
## Summary
- support new `otherName` column in manga DB
- capture empty subfolder names as `otherName` while scanning
- search API also checks `otherName`

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684d646c62548328bac2d80ffbbde61e