### PR TITLE
Refactor overlay usage

### DIFF
--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -1,5 +1,5 @@
 // /src/pages/home.js
-import { showToast, showConfirm } from "/src/core/ui.js";
+import { showToast, showConfirm, showOverlay, hideOverlay } from "/src/core/ui.js";
 
 function renderSourceList(listId, keys, type) {
   const container = document.getElementById(listId);
@@ -14,8 +14,7 @@ function renderSourceList(listId, keys, type) {
       localStorage.setItem("sourceKey", key);
 
       // Hiện overlay loading
-      const overlay = document.getElementById("loading-overlay");
-      overlay?.classList.remove("hidden");
+      showOverlay();
 
       try {
         if (type === "manga") {
@@ -33,7 +32,7 @@ function renderSourceList(listId, keys, type) {
           }
           // Chuyển trang sau khi mọi thứ xong
           window.location.href = "/movie/index.html";
-          overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
+          hideOverlay(); // Ẩn overlay nếu lỗi
         } else if (type === "music") {
           const resp = await fetch(`/api/music/music-folder?key=${key}`);
           const data = await resp.json();
@@ -46,13 +45,13 @@ function renderSourceList(listId, keys, type) {
           }
 
           window.location.href = "/music/index.html";
-          overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
+          hideOverlay(); // Ẩn overlay nếu lỗi
         }
       } catch (err) {
         // Có thể hiện toast lỗi nếu muốn
         console.error("❌ Lỗi check/scan DB:", err);
         alert("Lỗi khi load dữ liệu!"); // hoặc showToast nếu đã dùng ở home
-        overlay?.classList.add("hidden"); // Ẩn overlay nếu lỗi
+        hideOverlay(); // Ẩn overlay nếu lỗi
       }
     };
     container.appendChild(btn);
@@ -62,8 +61,7 @@ function renderSourceList(listId, keys, type) {
 // Đảm bảo 2 script đã load lên window trước khi render (script inline .js nên yên tâm)
 // Đảm bảo overlay luôn ẩn khi vào lại trang Home
 window.addEventListener("DOMContentLoaded", () => {
-  const overlay = document.getElementById("loading-overlay");
-  overlay?.classList.add("hidden");
+  hideOverlay();
   // ... gọi renderSourceList như cũ
   renderSourceList("manga-list", window.mangaKeys || [], "manga");
   renderSourceList("movie-list", window.movieKeys || [], "movie");

--- a/frontend/src/pages/manga/favorites.js
+++ b/frontend/src/pages/manga/favorites.js
@@ -2,7 +2,7 @@
 
 import { getRootFolder, getSourceKey } from "/src/core/storage.js";
 import { renderFolderCard } from "/src/components/folderCard.js";
-import { showToast } from "/src/core/ui.js";
+import { showToast, showOverlay, hideOverlay } from "/src/core/ui.js";
 import { loadFolder } from "/src/core/folder.js";
 let allFavorites = [];
 let currentPage = 0;
@@ -84,7 +84,7 @@ async function loadFavorites() {
   const key = getSourceKey();
   if (!root || !key) return showToast("❌ Thiếu root hoặc sourceKey");
 
-  document.getElementById("loading-overlay")?.classList.remove("hidden");
+  showOverlay();
 
   try {
     const res = await fetch(
@@ -99,7 +99,7 @@ async function loadFavorites() {
     showToast("❌ Lỗi khi tải danh sách yêu thích");
     console.error("favorite.js error:", err);
   } finally {
-    document.getElementById("loading-overlay")?.classList.add("hidden");
+    hideOverlay();
   }
 }
 

--- a/frontend/src/pages/manga/reader.js
+++ b/frontend/src/pages/manga/reader.js
@@ -11,6 +11,8 @@ import {
   filterManga,
   toggleSearchBar,
   showToast,
+  showOverlay,
+  hideOverlay,
 } from "/src/core/ui.js";
 import { setupGlobalClickToCloseUI } from "/src/core/events.js";
 
@@ -19,7 +21,7 @@ window.addEventListener("DOMContentLoaded", initializeReader);
  * Fetch and render reader data based on the URL path.
  */
 async function initializeReader() {
-  document.getElementById("loading-overlay")?.classList.remove("hidden");
+  showOverlay();
 
   const sourceKey = getSourceKey();
   const rootFolder = getRootFolder();
@@ -45,7 +47,7 @@ async function initializeReader() {
     const data = await response.json();
 
     if (data.type === "reader" && Array.isArray(data.images)) {
-      document.getElementById("loading-overlay")?.classList.add("hidden");  // ✅ Ẩn overlay sau khi render
+      hideOverlay(); // ✅ Ẩn overlay sau khi render
 
       renderReader(data.images);
       setupReaderUIEvents();

--- a/frontend/src/pages/movie/favorites.js
+++ b/frontend/src/pages/movie/favorites.js
@@ -1,7 +1,7 @@
 // 📁 frontend/src/pages/movie/favorites.js
 
 import { getSourceKey } from "/src/core/storage.js";
-import { showToast } from "/src/core/ui.js";
+import { showToast, showOverlay, hideOverlay } from "/src/core/ui.js";
 import { renderMovieCardWithFavorite } from "/src/components/movie/movieCard.js";
 
 let allFavorites = [];
@@ -91,7 +91,7 @@ async function loadFavoritesMovie() {
   const key = getSourceKey();
   if (!key) return showToast("❌ Thiếu sourceKey");
 
-  document.getElementById("loading-overlay")?.classList.remove("hidden");
+  showOverlay();
 
   try {
     const res = await fetch(`/api/movie/favorite-movie?key=${encodeURIComponent(key)}`);
@@ -102,7 +102,7 @@ async function loadFavoritesMovie() {
     showToast("❌ Lỗi khi tải danh sách yêu thích phim");
     console.error("favorite-movie.js error:", err);
   } finally {
-    document.getElementById("loading-overlay")?.classList.add("hidden");
+    hideOverlay();
   }
 }
 

--- a/frontend/src/pages/select.js
+++ b/frontend/src/pages/select.js
@@ -1,5 +1,11 @@
 // 📁 frontend/src/select.js
-import { withLoading, showToast, showConfirm } from "/src/core/ui.js";
+import {
+  withLoading,
+  showToast,
+  showConfirm,
+  showOverlay,
+  hideOverlay,
+} from "/src/core/ui.js";
 import {
   requireSourceKey,
   getSourceKey,
@@ -144,8 +150,7 @@ document
       showToast("❌ Lỗi khi xoá DB");
       console.error("❌ reset-all-db:", err);
     } finally {
-      const overlay = document.getElementById("loading-overlay");
-      overlay?.classList.add("hidden");
+      hideOverlay();
     }
   });
 


### PR DESCRIPTION
## Summary
- centralize overlay show/hide in various pages
- import new helpers from ui.js

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684d56bf68008328b54db2c954be9d57