### PR TITLE
Add scroll page navigation in footer

### DIFF
--- a/frontend/public/manga/reader.html
+++ b/frontend/public/manga/reader.html
@@ -52,25 +52,18 @@
 
     <footer id="reader-footer">
       <div class="reader-footer-inner">
-        <button id="prev-chapter-btn">⬅ Prev</button>
+        <button
+          id="prev-page-btn"
+          class="scroll-page-btn hidden"
+          aria-label="Prev page"
+        >
+          <span class="icon">⬅</span>
+          <span class="label">Prev Page</span>
+        </button>
         <div class="footer-center">
-          <button
-            id="prev-page-btn"
-            class="scroll-page-btn hidden"
-            aria-label="Prev page"
-          >
-            <span class="icon">⬅</span>
-            <span class="label">Prev Page</span>
-          </button>
+          <button id="prev-chapter-btn">⬅ Prev</button>
           <div id="page-info">Trang ? / ?</div>
-          <button
-            id="next-page-btn"
-            class="scroll-page-btn hidden"
-            aria-label="Next page"
-          >
-            <span class="label">Next Page</span>
-            <span class="icon">➡</span>
-          </button>
+          <button id="next-chapter-btn">Next ➡</button>
           <div
             id="image-count-info"
             style="font-size: 13px; color: #ccc; margin-top: 2px"
@@ -78,7 +71,14 @@
             ? / ? (Page: ?)
           </div>
         </div>
-        <button id="next-chapter-btn">Next ➡</button>
+        <button
+          id="next-page-btn"
+          class="scroll-page-btn hidden"
+          aria-label="Next page"
+        >
+          <span class="label">Next Page</span>
+          <span class="icon">➡</span>
+        </button>
       </div>
     </footer>
     <div id="loading-overlay" class="hidden">

--- a/frontend/public/manga/reader.html
+++ b/frontend/public/manga/reader.html
@@ -53,8 +53,18 @@
     <footer id="reader-footer">
       <div class="reader-footer-inner">
         <button id="prev-chapter-btn">⬅ Prev</button>
-        <div style="text-align: center">
+        <div class="footer-center">
           <div id="page-info">Trang ? / ?</div>
+          <div id="scroll-page-nav" class="scroll-page-nav hidden">
+            <button id="prev-page-btn" aria-label="Prev page">
+              <span class="icon">⬅</span>
+              <span class="label">Prev Page</span>
+            </button>
+            <button id="next-page-btn" aria-label="Next page">
+              <span class="label">Next Page</span>
+              <span class="icon">➡</span>
+            </button>
+          </div>
           <div
             id="image-count-info"
             style="font-size: 13px; color: #ccc; margin-top: 2px"

--- a/frontend/public/manga/reader.html
+++ b/frontend/public/manga/reader.html
@@ -54,17 +54,23 @@
       <div class="reader-footer-inner">
         <button id="prev-chapter-btn">⬅ Prev</button>
         <div class="footer-center">
+          <button
+            id="prev-page-btn"
+            class="scroll-page-btn hidden"
+            aria-label="Prev page"
+          >
+            <span class="icon">⬅</span>
+            <span class="label">Prev Page</span>
+          </button>
           <div id="page-info">Trang ? / ?</div>
-          <div id="scroll-page-nav" class="scroll-page-nav hidden">
-            <button id="prev-page-btn" aria-label="Prev page">
-              <span class="icon">⬅</span>
-              <span class="label">Prev Page</span>
-            </button>
-            <button id="next-page-btn" aria-label="Next page">
-              <span class="label">Next Page</span>
-              <span class="icon">➡</span>
-            </button>
-          </div>
+          <button
+            id="next-page-btn"
+            class="scroll-page-btn hidden"
+            aria-label="Next page"
+          >
+            <span class="label">Next Page</span>
+            <span class="icon">➡</span>
+          </button>
           <div
             id="image-count-info"
             style="font-size: 13px; color: #ccc; margin-top: 2px"

--- a/frontend/src/core/reader/scroll.js
+++ b/frontend/src/core/reader/scroll.js
@@ -37,11 +37,28 @@ export function renderScrollReader(
   window.onscroll = syncScrollState;
 
   const pageInfo = document.getElementById("page-info");
+  const prevPageBtn = document.getElementById("prev-page-btn");
+  const nextPageBtn = document.getElementById("next-page-btn");
+  const scrollPageNav = document.getElementById("scroll-page-nav");
   if (pageInfo) {
     pageInfo.style.cursor = "pointer";
     pageInfo.onclick = null; // 🧹 xoá sự kiện cũ trước khi gán mới
     pageInfo.onclick = () => showPageModal();
     updateReaderPageInfo(currentPageIndex + 1, totalPages);
+  }
+
+  if (scrollPageNav && prevPageBtn && nextPageBtn) {
+    if (totalPages > 1) {
+      scrollPageNav.classList.remove("hidden");
+    }
+    prevPageBtn.onclick = () => {
+      if (currentPageIndex > 0) switchScrollPage(currentPageIndex - 1);
+    };
+    nextPageBtn.onclick = () => {
+      if (currentPageIndex < totalPages - 1)
+        switchScrollPage(currentPageIndex + 1);
+    };
+    updateNavButtons();
   }
 
   function renderScrollPage(imageList) {
@@ -113,7 +130,14 @@ export function renderScrollReader(
     renderScrollPage(pages[currentPageIndex]);
     setupScrollLazyLoad(wrapper, pages[currentPageIndex]);
     updateReaderPageInfo(currentPageIndex + 1, totalPages);
+    updateNavButtons();
     scrollTo(wrapper);
+  }
+
+  function updateNavButtons() {
+    if (!prevPageBtn || !nextPageBtn) return;
+    prevPageBtn.disabled = currentPageIndex === 0;
+    nextPageBtn.disabled = currentPageIndex >= totalPages - 1;
   }
 
   function scrollTo(elem) {

--- a/frontend/src/core/reader/scroll.js
+++ b/frontend/src/core/reader/scroll.js
@@ -39,7 +39,6 @@ export function renderScrollReader(
   const pageInfo = document.getElementById("page-info");
   const prevPageBtn = document.getElementById("prev-page-btn");
   const nextPageBtn = document.getElementById("next-page-btn");
-  const scrollPageNav = document.getElementById("scroll-page-nav");
   if (pageInfo) {
     pageInfo.style.cursor = "pointer";
     pageInfo.onclick = null; // 🧹 xoá sự kiện cũ trước khi gán mới
@@ -47,9 +46,10 @@ export function renderScrollReader(
     updateReaderPageInfo(currentPageIndex + 1, totalPages);
   }
 
-  if (scrollPageNav && prevPageBtn && nextPageBtn) {
+  if (prevPageBtn && nextPageBtn) {
     if (totalPages > 1) {
-      scrollPageNav.classList.remove("hidden");
+      prevPageBtn.classList.remove("hidden");
+      nextPageBtn.classList.remove("hidden");
     }
     prevPageBtn.onclick = () => {
       if (currentPageIndex > 0) switchScrollPage(currentPageIndex - 1);

--- a/frontend/src/styles/pages/manga/reader.css
+++ b/frontend/src/styles/pages/manga/reader.css
@@ -214,7 +214,11 @@ img {
 
 .footer-center {
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  gap: 10px;
 }
 
 #reader-footer button {
@@ -239,23 +243,16 @@ img {
   padding: 4px 0;
 }
 
-.scroll-page-nav {
-  margin-top: 6px;
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-}
-
-.scroll-page-nav.hidden {
+.scroll-page-btn.hidden {
   display: none;
 }
 
-.scroll-page-nav .label {
-  margin: 0 2px;
+.scroll-page-btn .label {
+  margin: 0 4px;
 }
 
 @media (max-width: 768px) {
-  .scroll-page-nav .label {
+  .scroll-page-btn .label {
     display: none;
   }
 }

--- a/frontend/src/styles/pages/manga/reader.css
+++ b/frontend/src/styles/pages/manga/reader.css
@@ -212,6 +212,11 @@ img {
   margin: 0 auto;
 }
 
+.footer-center {
+  flex: 1;
+  text-align: center;
+}
+
 #reader-footer button {
   background: #ffffff22;
   color: white;
@@ -232,6 +237,27 @@ img {
   font-weight: bold;
   font-size: 15px;
   padding: 4px 0;
+}
+
+.scroll-page-nav {
+  margin-top: 6px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.scroll-page-nav.hidden {
+  display: none;
+}
+
+.scroll-page-nav .label {
+  margin: 0 2px;
+}
+
+@media (max-width: 768px) {
+  .scroll-page-nav .label {
+    display: none;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add prev/next page buttons inside the reader footer
- show page buttons only when multiple pages
- hide button labels on small screens

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684e2129bd8c8328ae7b77646d97b5c3