### PR TITLE
Add CI workflow and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit and integration tests
+        run: npm test
+      - name: Build project
+        run: npm run build
+      - name: Deploy
+        run: echo "Deploying..."

--- a/backend/__tests__/imageUtils.test.js
+++ b/backend/__tests__/imageUtils.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { hasImageRecursively } = require('../utils/imageUtils');
+
+describe('hasImageRecursively', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'imgtest-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns true when directory contains an image', () => {
+    const imgPath = path.join(tmpDir, 'picture.jpg');
+    fs.writeFileSync(imgPath, '');
+    expect(hasImageRecursively(tmpDir)).toBe(true);
+  });
+
+  test('returns false when directory has no images', () => {
+    const sub = path.join(tmpDir, 'sub');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'text.txt'), 'hello');
+    expect(hasImageRecursively(tmpDir)).toBe(false);
+  });
+});

--- a/backend/__tests__/increase-view.test.js
+++ b/backend/__tests__/increase-view.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('../utils/config', () => ({
+  getRootPath: jest.fn(() => '/tmp'),
+}));
+
+const router = require('../api/increase-view');
+const { getDB } = require('../utils/db');
+
+const TEST_DB_KEY = 'TEST_VIEW';
+
+describe('POST /increase-view', () => {
+  const dbFile = path.join(__dirname, '../data', `${TEST_DB_KEY}.db`);
+  let app;
+
+  beforeAll(() => {
+    if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+    app = express();
+    app.use(express.json());
+    app.use(router);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+  });
+
+  test('increments view count', async () => {
+    const body = { path: '1/Naruto', dbkey: TEST_DB_KEY, rootKey: '1' };
+    await request(app).post('/increase-view').send(body).expect(200);
+    await request(app).post('/increase-view').send(body).expect(200);
+
+    const db = getDB(TEST_DB_KEY);
+    const row = db
+      .prepare('SELECT count FROM views WHERE root = ? AND path = ?')
+      .get('1', '1/Naruto');
+    expect(row.count).toBe(2);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "day-la-note-comment-chi-run-thoi": "node backend/server.js",
     "build": "node scripts/build.js",
-    "start": "npm run build && node backend/server.js"
+    "start": "npm run build && node backend/server.js",
+    "test": "jest"
   },
   "keywords": [
     "manga",
@@ -34,6 +35,8 @@
     "string-natural-compare": "^3.0.1"
   },
   "devDependencies": {
-    "esbuild": "^0.19.0"
+    "esbuild": "^0.19.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for build, test and deploy
- configure Jest and Supertest in package.json
- add unit test for `hasImageRecursively`
- add integration test for view counter API

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e279b8dc88328b73091672483da39