### PR TITLE
Implement infinite scroll in search dropdown

### DIFF
--- a/backend/api/manga/folder-cache.js
+++ b/backend/api/manga/folder-cache.js
@@ -81,15 +81,22 @@ router.get("/folder-cache", async (req, res) => {
       });
     }
     if (mode === "search") {
-      // Tìm kiếm theo tên
+      // Tìm kiếm theo tên có phân trang
       if (!q || typeof q !== "string") {
         return res.status(400).json({ error: "Missing query" });
       }
-      const rows = db.prepare(`
-        SELECT name, path, thumbnail, isFavorite FROM folders
-        WHERE root = ? AND (name LIKE ? OR otherName LIKE ?)
-        ORDER BY name ASC LIMIT 50
-      `).all(root, `%${q}%`, `%${q}%`);
+
+      const lim = limitNum > 0 ? limitNum : 50;
+      const off = offsetNum > 0 ? offsetNum : 0;
+
+      const rows = db
+        .prepare(
+          `SELECT name, path, thumbnail, isFavorite FROM folders
+           WHERE root = ? AND (name LIKE ? OR otherName LIKE ?)
+           ORDER BY name ASC LIMIT ? OFFSET ?`
+        )
+        .all(root, `%${q}%`, `%${q}%`, lim, off);
+
       return res.json(rows);
     }
     // Nếu mode không hợp lệ

--- a/frontend/src/core/events.js
+++ b/frontend/src/core/events.js
@@ -24,3 +24,17 @@ export function setupGlobalClickToCloseUI() {
     }
   });
 }
+
+export function setupSearchLoadMore(onLoadMore) {
+  const dropdown = document.getElementById("search-dropdown");
+  if (!dropdown || dropdown.dataset.loadMoreInit) return;
+  dropdown.dataset.loadMoreInit = "1";
+  dropdown.addEventListener("scroll", () => {
+    if (
+      dropdown.scrollTop + dropdown.clientHeight >=
+      dropdown.scrollHeight - 20
+    ) {
+      onLoadMore();
+    }
+  });
+}

--- a/frontend/src/pages/manga/index.js
+++ b/frontend/src/pages/manga/index.js
@@ -18,7 +18,7 @@ import {
   changeRootFolder,
   recentViewedKey,
 } from "/src/core/storage.js";
-import { setupGlobalClickToCloseUI } from "/src/core/events.js";
+import { setupGlobalClickToCloseUI, setupSearchLoadMore } from "/src/core/events.js";
 
 window.loadFolder = loadFolder;
 window.toggleDarkMode = toggleDarkMode;
@@ -64,6 +64,7 @@ async function initializeMangaHome() {
   renderRecentViewFromLocal();
 
   document.getElementById("floatingSearchInput")?.addEventListener("input", filterManga);
+  setupSearchLoadMore(() => filterManga(true));
   document.getElementById("searchToggle")?.addEventListener("click", toggleSearchBar);
   document.getElementById("sidebarToggle")?.addEventListener("click", toggleSidebar);
 

--- a/frontend/src/pages/manga/reader.js
+++ b/frontend/src/pages/manga/reader.js
@@ -14,7 +14,7 @@ import {
   showOverlay,
   hideOverlay,
 } from "/src/core/ui.js";
-import { setupGlobalClickToCloseUI } from "/src/core/events.js";
+import { setupGlobalClickToCloseUI, setupSearchLoadMore } from "/src/core/events.js";
 
 window.addEventListener("DOMContentLoaded", initializeReader);
 /**
@@ -67,6 +67,7 @@ function setupReaderUIEvents() {
   document.getElementById("sidebarToggle")?.addEventListener("click", toggleSidebar);
   document.getElementById("searchToggle")?.addEventListener("click", toggleSearchBar);
   document.getElementById("floatingSearchInput")?.addEventListener("input", filterManga);
+  setupSearchLoadMore(() => filterManga(true));
   document.getElementById("setThumbnailBtn")?.addEventListener("click", setRootThumbnail);
 }
 

--- a/frontend/src/pages/movie/index.js
+++ b/frontend/src/pages/movie/index.js
@@ -12,7 +12,7 @@ import {
   showToast,
   toggleSidebar,withLoading
 } from "/src/core/ui.js";
-import { setupGlobalClickToCloseUI } from "/src/core/events.js";
+import { setupGlobalClickToCloseUI, setupSearchLoadMore } from "/src/core/events.js";
 import { getMovieCache, setMovieCache } from "/src/core/storage.js";
 import {
   loadRandomSliders,
@@ -33,6 +33,7 @@ window.addEventListener("DOMContentLoaded", () => {
   document
     .getElementById("floatingSearchInput")
     ?.addEventListener("input", filterMovie);
+  setupSearchLoadMore(() => filterMovie(true));
   document
     .getElementById("searchToggle")
     ?.addEventListener("click", toggleSearchBar);

--- a/frontend/src/pages/movie/player.js
+++ b/frontend/src/pages/movie/player.js
@@ -18,6 +18,7 @@ import {
   setupRandomSectionsIfMissing,
 } from "/src/components/folderSlider.js";
 import { saveRecentViewedVideo } from "/src/core/storage.js";
+import { setupSearchLoadMore } from "/src/core/events.js";
 
 const urlParams = new URLSearchParams(window.location.search);
 const file = urlParams.get("file");
@@ -190,6 +191,7 @@ checkFavorite();
 document
   .getElementById("floatingSearchInput")
   ?.addEventListener("input", filterMovie);
+setupSearchLoadMore(() => filterMovie(true));
 
 document
   .getElementById("searchToggle")

--- a/frontend/src/pages/music/index.js
+++ b/frontend/src/pages/music/index.js
@@ -16,6 +16,7 @@ import {
   showConfirm,renderRecentViewedMusic,withLoading
 } from "/src/core/ui.js";
 import { filterMusic } from "/src/core/ui.js";
+import { setupSearchLoadMore } from "/src/core/events.js";
 import { buildThumbnailUrl } from "/src/core/ui.js";
 
 
@@ -33,6 +34,7 @@ window.addEventListener("DOMContentLoaded", () => {
   document
     .getElementById("floatingSearchInput")
     ?.addEventListener("input", filterMusic);
+  setupSearchLoadMore(() => filterMusic(true));
 
   document
     .getElementById("searchToggle")

--- a/frontend/src/pages/music/player.js
+++ b/frontend/src/pages/music/player.js
@@ -8,6 +8,7 @@ import {
   filterMusic,
   setupMusicSidebar,
 } from "/src/core/ui.js";
+import { setupSearchLoadMore } from "/src/core/events.js";
 import { buildThumbnailUrl } from "/src/core/ui.js";
 import { showPlaylistMenu } from "/src/components/music/playlistMenu.js";
 import { renderFolderSlider } from "/src/components/folderSlider.js";
@@ -89,6 +90,7 @@ document
 document
   .getElementById("floatingSearchInput")
   ?.addEventListener("input", filterMusic);
+setupSearchLoadMore(() => filterMusic(true));
 document.getElementById("sidebarToggle")?.addEventListener("click", () => {
   document.getElementById("sidebar-menu")?.classList.toggle("active");
 });


### PR DESCRIPTION
## Summary
- add limit/offset pagination to search API endpoints
- track search offsets and implement load-more logic
- handle dropdown scrolling and attach new scroll event
- integrate load-more logic across pages

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684ed4e6497c832886b7c6495c82c394