### PR TITLE
Implement infinite scroll search

### DIFF
--- a/backend/api/movie/video-cache.js
+++ b/backend/api/movie/video-cache.js
@@ -9,6 +9,8 @@ router.get("/video-cache", async (req, res) => {
     key,
     mode,
     type, // file | folder
+    limit = 0,
+    offset = 0,
   } = req.query;
 
   if (!key || !mode)
@@ -72,6 +74,8 @@ router.get("/video-cache", async (req, res) => {
       }
 
       const type = req.query.type || "video"; // mặc định video
+      const lim = parseInt(limit) > 0 ? parseInt(limit) : 50;
+      const off = parseInt(offset) > 0 ? parseInt(offset) : 0;
       let rows = [];
 
       if (type === "folder") {
@@ -85,7 +89,7 @@ router.get("/video-cache", async (req, res) => {
     ORDER BY name COLLATE NOCASE ASC
   `
           )
-          .all(`%${q}%`);
+          .all(`%${q}%`, lim, off);
       } else if (type === "all") {
         rows = db
           .prepare(
@@ -96,7 +100,7 @@ router.get("/video-cache", async (req, res) => {
     ORDER BY name COLLATE NOCASE ASC
   `
           )
-          .all(`%${q}%`);
+          .all(`%${q}%`, lim, off);
       } else {
         rows = db
           .prepare(
@@ -108,7 +112,7 @@ router.get("/video-cache", async (req, res) => {
     ORDER BY name COLLATE NOCASE ASC
   `
           )
-          .all(`%${q}%`);
+          .all(`%${q}%`, lim, off);
       }
 
       return res.json({ folders: rows });

--- a/backend/api/music/audio-cache.js
+++ b/backend/api/music/audio-cache.js
@@ -5,7 +5,7 @@ const { getMusicDB } = require("../../utils/db");
 const { getRootPath } = require("../../utils/config");
 
 router.get("/audio-cache", async (req, res) => {
-  const { key, mode, type } = req.query;
+  const { key, mode, type, limit = 0, offset = 0 } = req.query;
 
   if (!key || !mode) return res.status(400).json({ error: "Missing key or mode" });
 
@@ -61,6 +61,8 @@ router.get("/audio-cache", async (req, res) => {
       }
 
       const searchType = req.query.type || "audio";
+      const lim = parseInt(limit) > 0 ? parseInt(limit) : 50;
+      const off = parseInt(offset) > 0 ? parseInt(offset) : 0;
       if (searchType === "folder") {
         rows = db.prepare(`
           SELECT name, path, thumbnail, type, viewCount, isFavorite
@@ -69,7 +71,8 @@ router.get("/audio-cache", async (req, res) => {
             AND name != '.thumbnail'
             AND name LIKE ?
           ORDER BY name COLLATE NOCASE ASC
-        `).all(`%${q}%`);
+          LIMIT ? OFFSET ?
+        `).all(`%${q}%`, lim, off);
       } else if (searchType === "all") {
         rows = db.prepare(`
           SELECT name, path, thumbnail, type, viewCount, isFavorite
@@ -77,7 +80,8 @@ router.get("/audio-cache", async (req, res) => {
           WHERE name != '.thumbnail'
             AND name LIKE ?
           ORDER BY name COLLATE NOCASE ASC
-        `).all(`%${q}%`);
+          LIMIT ? OFFSET ?
+        `).all(`%${q}%`, lim, off);
       } else {
         rows = db.prepare(`
           SELECT name, path, thumbnail, type, viewCount, isFavorite
@@ -86,7 +90,8 @@ router.get("/audio-cache", async (req, res) => {
             AND name != '.thumbnail'
             AND name LIKE ?
           ORDER BY name COLLATE NOCASE ASC
-        `).all(`%${q}%`);
+          LIMIT ? OFFSET ?
+        `).all(`%${q}%`, lim, off);
       }
 
       return res.json({ folders: rows });


### PR DESCRIPTION
## Summary
- add limit/offset parameters to search APIs for manga, movie and music
- maintain search state on frontend and append results while scrolling
- show loaders while fetching additional pages

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684edec6ffd48328ad84b1552faca5fb