### PR TITLE
Add security check for selected root keys

### DIFF
--- a/backend/.env exampe
+++ b/backend/.env exampe
@@ -5,6 +5,10 @@ ROOT_CARTOON=E:\disk3
 ### root movie
 V_MOVIE=E:\File\Videos
 
+# Keys cần mật khẩu
+SECURITY=V_MOVIE
+SECURITY_PASSWORD=changeme
+
 # -------- IP allow
 ALLOWED_HOSTNAMES=exampe
 ALLOWED_IPS=exampe

--- a/backend/api/login.js
+++ b/backend/api/login.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const { login, secureKeys } = require('../middleware/security');
+
+router.post('/login', (req, res) => {
+  const { key, password } = req.body || {};
+  const k = (key || '').toUpperCase();
+  if (!secureKeys.includes(k)) {
+    return res.status(400).json({ error: 'Invalid key' });
+  }
+  const token = login(k, password);
+  if (!token) return res.status(401).json({ error: 'Wrong password' });
+  res.json({ token });
+});
+
+module.exports = router;

--- a/backend/middleware/security.js
+++ b/backend/middleware/security.js
@@ -1,0 +1,28 @@
+const crypto = require('crypto');
+
+const secureKeys = (process.env.SECURITY || '')
+  .split(',')
+  .map((s) => s.trim().toUpperCase())
+  .filter(Boolean);
+const securityPassword = process.env.SECURITY_PASSWORD || '';
+
+const sessions = new Map();
+
+function login(key, password) {
+  const k = key.toUpperCase();
+  if (!secureKeys.includes(k) || password !== securityPassword) return null;
+  const token = crypto.randomBytes(16).toString('hex');
+  sessions.set(token, k);
+  return token;
+}
+
+function middleware(req, res, next) {
+  if (secureKeys.length === 0) return next();
+  const key = (req.query.key || req.body?.key || '').toUpperCase();
+  if (!secureKeys.includes(key)) return next();
+  const token = req.headers['x-security-token'];
+  if (token && sessions.get(token) === key) return next();
+  return res.status(401).json({ error: 'Unauthorized' });
+}
+
+module.exports = { middleware, login, secureKeys };

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,6 +13,7 @@ const {
 } = require("./utils/config");
 const { ROOT_PATHS } = require("./utils/config");
 const authMiddleware = require("./middleware/auth"); // 🆕 Middleware kiểm tra IP/hostname
+const security = require("./middleware/security");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -23,10 +24,12 @@ app.use(compression());
 
 // 🛡️ Middleware kiểm tra IP/hostname (tách riêng ra file middleware/auth.js)
 app.use(authMiddleware);
+app.use(security.middleware);
 
 // ✅ API chính
 app.use("/api/manga", require("./api/manga/folder-cache")); // 🌟 API gộp random, top, search, path, folders
 app.use("/api", require("./api/increase-view")); // 📈 Ghi lượt xem
+app.use("/api", require("./api/login"));
 app.use("/api/manga", require("./api/manga/reset-cache")); // 🔁 Reset cache DB
 // ✅ Đăng ký route /api/scan trong server.js:
 app.use("/api/manga", require("./api/manga/scan"));
@@ -109,9 +112,14 @@ app.get("/api/source-keys.js", (req, res) => {
   const manga = getAllMangaKeys(); // ROOT_
   const movie = getAllMovieKeys(); // V_
   const music = getAllMusicKeys(); // M_
+  const secure = (process.env.SECURITY || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
   const js = `window.mangaKeys = ${JSON.stringify(manga)};
 window.movieKeys = ${JSON.stringify(movie)};
-window.musicKeys = ${JSON.stringify(music)};`;
+window.musicKeys = ${JSON.stringify(music)};
+window.securityKeys = ${JSON.stringify(secure)};`;
   res.type("application/javascript").send(js);
 });
 

--- a/frontend/public/manga/favorites.html
+++ b/frontend/public/manga/favorites.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/dist/manga/favorites.css" />
     <link rel="icon" type="image/png" href="/default/favicon.png" />
+    <script src="/api/source-keys.js"></script>
     <script src="/dist/manga/favorites.js"></script>
   </head>
   <body>

--- a/frontend/public/manga/index.html
+++ b/frontend/public/manga/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" href="/default/favicon.png" />
     <title>📚 MyLocalManga</title>
     <link rel="stylesheet" href="/dist/manga/index.css" />
+    <script src="/api/source-keys.js"></script>
     <script src="/dist/manga/index.js"></script>
   </head>
   <body>

--- a/frontend/public/manga/reader.html
+++ b/frontend/public/manga/reader.html
@@ -15,6 +15,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/pinch-zoom-js@2.3.4/dist/pinch-zoom.umd.min.js"></script>
+    <script src="/api/source-keys.js"></script>
   </head>
   <body class="reader-page">
 

--- a/frontend/public/manga/select.html
+++ b/frontend/public/manga/select.html
@@ -5,6 +5,7 @@
     <title>Chọn Manga Folder</title>
     <link rel="stylesheet" href="/dist/select.css" />
     <link rel="icon" type="image/png" href="/default/favicon.png" />
+    <script src="/api/source-keys.js"></script>
     <script src="/dist/select.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>

--- a/frontend/public/movie/favorites.html
+++ b/frontend/public/movie/favorites.html
@@ -7,6 +7,7 @@
     <!-- CSS chung -->
     <link rel="stylesheet" href="/dist/movie/favorites.css" />
     <link rel="icon" type="image/png" href="/default/favicon.png" />
+    <script src="/api/source-keys.js"></script>
     <script src="/dist/movie/favorites.js"></script>
   </head>
   <body>

--- a/frontend/public/movie/index.html
+++ b/frontend/public/movie/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Danh sách phim</title>
     <link rel="stylesheet" href="/dist/movie/index.css" />
+    <script src="/api/source-keys.js"></script>
   </head>
 
   <body>

--- a/frontend/public/movie/player.html
+++ b/frontend/public/movie/player.html
@@ -75,6 +75,7 @@
     </div>
 
     <div id="loading-overlay" class="hidden">⏳ Đang tải...</div>
+    <script src="/api/source-keys.js"></script>
     <script src="/dist/movie/player.js"></script>
     <script type="module" src="/src/core/ui.js"></script>
   </body>

--- a/frontend/public/music/index.html
+++ b/frontend/public/music/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Danh sách nhạc</title>
     <link rel="stylesheet" href="/dist/music/index.css" />
+    <script src="/api/source-keys.js"></script>
   </head>
   <body>
     <header id="site-header" class="site-header">

--- a/frontend/public/music/player.html
+++ b/frontend/public/music/player.html
@@ -5,6 +5,7 @@
     <title>Nghe nhạc</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/dist/music/player.css" />
+    <script src="/api/source-keys.js"></script>
   </head>
   <body>
     <!-- HEADER: giữ nguyên, không được xoá -->

--- a/frontend/src/core/security.js
+++ b/frontend/src/core/security.js
@@ -1,0 +1,39 @@
+export function setupSecurityFetch() {
+  const orig = window.fetch;
+  window.fetch = async (url, options = {}) => {
+    const key = localStorage.getItem('sourceKey');
+    if (window.securityKeys?.includes(key)) {
+      const token = localStorage.getItem(`securityToken::${key}`);
+      if (token) {
+        options.headers = options.headers || {};
+        options.headers['X-Security-Token'] = token;
+      }
+    }
+    return orig(url, options);
+  };
+}
+
+export async function ensureAuth(key) {
+  if (!window.securityKeys?.includes(key)) return true;
+  const stored = localStorage.getItem(`securityToken::${key}`);
+  if (stored) return true;
+  const password = prompt('Enter password');
+  if (!password) return false;
+  try {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, password })
+    });
+    if (!res.ok) {
+      alert('Sai password');
+      return false;
+    }
+    const data = await res.json();
+    localStorage.setItem(`securityToken::${key}`, data.token);
+    return true;
+  } catch (err) {
+    alert('Lỗi xác thực');
+    return false;
+  }
+}

--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -1,5 +1,6 @@
 // /src/pages/home.js
 import { showToast, showConfirm, showOverlay, hideOverlay } from "/src/core/ui.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 
 function renderSourceList(listId, keys, type) {
   const container = document.getElementById(listId);
@@ -12,7 +13,7 @@ function renderSourceList(listId, keys, type) {
     btn.textContent = `📁 ${key}`;
     btn.onclick = async () => {
       localStorage.setItem("sourceKey", key);
-
+      if (!(await ensureAuth(key))) return;
       // Hiện overlay loading
       showOverlay();
 
@@ -61,6 +62,7 @@ function renderSourceList(listId, keys, type) {
 // Đảm bảo 2 script đã load lên window trước khi render (script inline .js nên yên tâm)
 // Đảm bảo overlay luôn ẩn khi vào lại trang Home
 window.addEventListener("DOMContentLoaded", () => {
+  setupSecurityFetch();
   hideOverlay();
   // ... gọi renderSourceList như cũ
   renderSourceList("manga-list", window.mangaKeys || [], "manga");

--- a/frontend/src/pages/manga/favorites.js
+++ b/frontend/src/pages/manga/favorites.js
@@ -3,6 +3,7 @@
 import { getRootFolder, getSourceKey } from "/src/core/storage.js";
 import { renderFolderCard } from "/src/components/folderCard.js";
 import { showToast, showOverlay, hideOverlay } from "/src/core/ui.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import { loadFolder } from "/src/core/folder.js";
 let allFavorites = [];
 let currentPage = 0;
@@ -103,5 +104,12 @@ async function loadFavorites() {
   }
 }
 
-window.addEventListener("DOMContentLoaded", loadFavorites);
+window.addEventListener("DOMContentLoaded", async () => {
+  setupSecurityFetch();
+  const key = getSourceKey();
+  if (!(await ensureAuth(key))) {
+    return (window.location.href = "/home.html");
+  }
+  loadFavorites();
+});
 window.loadFolder = loadFolder;

--- a/frontend/src/pages/manga/index.js
+++ b/frontend/src/pages/manga/index.js
@@ -18,6 +18,7 @@ import {
   changeRootFolder,
   recentViewedKey,
 } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import { setupGlobalClickToCloseUI } from "/src/core/events.js";
 
 window.loadFolder = loadFolder;
@@ -29,7 +30,11 @@ window.getRootFolder = getRootFolder;
 window.addEventListener("DOMContentLoaded", initializeMangaHome);
 
 async function initializeMangaHome() {
-   const sourceKey = getSourceKey();
+  setupSecurityFetch();
+  const sourceKey = getSourceKey();
+  if (!(await ensureAuth(sourceKey))) {
+    return (window.location.href = "/home.html");
+  }
 
   // 🛑 Nếu chưa chọn source ➜ về home
   if (!sourceKey) {

--- a/frontend/src/pages/manga/reader.js
+++ b/frontend/src/pages/manga/reader.js
@@ -4,6 +4,7 @@ import {
   requireRootFolder,
   setRootThumbCache,
 } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import { renderReader, getCurrentImage } from "/src/core/reader/index.js";
 import {
   setupSidebar,
@@ -25,6 +26,11 @@ let currentFolderPath = "";
  * Fetch and render reader data based on the URL path.
  */
 async function initializeReader() {
+  setupSecurityFetch();
+  const k = getSourceKey();
+  if (!(await ensureAuth(k))) {
+    return (window.location.href = "/home.html");
+  }
   showOverlay();
 
   const sourceKey = getSourceKey();

--- a/frontend/src/pages/movie/favorites.js
+++ b/frontend/src/pages/movie/favorites.js
@@ -1,6 +1,7 @@
 // 📁 frontend/src/pages/movie/favorites.js
 
 import { getSourceKey } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import {
   showToast,
   showOverlay,
@@ -184,4 +185,11 @@ async function loadFavoritesMovie() {
   }
 }
 
-window.addEventListener("DOMContentLoaded", loadFavoritesMovie);
+window.addEventListener("DOMContentLoaded", async () => {
+  setupSecurityFetch();
+  const key = getSourceKey();
+  if (!(await ensureAuth(key))) {
+    return (window.location.href = "/home.html");
+  }
+  loadFavoritesMovie();
+});

--- a/frontend/src/pages/movie/index.js
+++ b/frontend/src/pages/movie/index.js
@@ -1,6 +1,7 @@
 import {} from "/src/components/folderCard.js";
 import { renderFolderSlider } from "/src/components/folderSlider.js";
 import { getSourceKey } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import { renderMovieCardWithFavorite } from "/src/components/movie/movieCard.js";
 import { recentViewedVideoKey } from "/src/core/storage.js";
 
@@ -20,7 +21,12 @@ import {
 } from "/src/components/folderSlider.js";
 
 // 👉 Gắn sự kiện UI
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
+  setupSecurityFetch();
+  const key = getSourceKey();
+  if (!(await ensureAuth(key))) {
+    return (window.location.href = "/home.html");
+  }
   const initialPath = getInitialPathFromURL();
   loadMovieFolder(initialPath);
   setupExtractThumbnailButton();

--- a/frontend/src/pages/music/index.js
+++ b/frontend/src/pages/music/index.js
@@ -9,6 +9,7 @@ import {
   getMusicCache,
   setMusicCache,recentViewedMusicKey
 } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 import {
   showToast,
   toggleSearchBar,
@@ -19,7 +20,12 @@ import { filterMusic } from "/src/core/ui.js";
 import { buildThumbnailUrl } from "/src/core/ui.js";
 
 
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
+  setupSecurityFetch();
+  const key = getSourceKey();
+  if (!(await ensureAuth(key))) {
+    return (window.location.href = "/home.html");
+  }
   const initialPath = getInitialPathFromURL();
   loadMusicFolder(initialPath);
   setupMusicSidebar(); // ✅ music

--- a/frontend/src/pages/select.js
+++ b/frontend/src/pages/select.js
@@ -13,6 +13,7 @@ import {
   getRootThumbCache,
   setRootThumbCache,
 } from "/src/core/storage.js";
+import { ensureAuth, setupSecurityFetch } from "/src/core/security.js";
 /**
  * 📂 Fetch danh sách folder gốc và render ra giao diện
  */
@@ -170,4 +171,11 @@ document
     location.reload();
   });
 
-window.addEventListener("DOMContentLoaded", loadRootFolders);
+window.addEventListener("DOMContentLoaded", async () => {
+  setupSecurityFetch();
+  const key = getSourceKey();
+  if (!(await ensureAuth(key))) {
+    return (window.location.href = "/home.html");
+  }
+  loadRootFolders();
+});

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ Sau đây là các bước cài đặt cơ bản.
    - `V_*`      : Thư mục chứa phim.
    - `M_*`      : Thư mục chứa nhạc.
    - `ALLOWED_HOSTNAMES` và `ALLOWED_IPS` dùng để giới hạn truy cập.
+   - `SECURITY` : Danh sách root key yêu cầu mật khẩu, phân cách bằng dấu phẩy.
+   - `SECURITY_PASSWORD` : Mật khẩu truy cập cho các key trên.
 
 ## Cài đặt phụ thuộc
 


### PR DESCRIPTION
## Summary
- add SECURITY and SECURITY_PASSWORD to env example
- implement backend middleware and login API to enforce password for specific root keys
- expose list of secure keys in `/api/source-keys.js`
- add frontend utilities for auth handling and fetch header injection
- require authentication on pages when using a secure key
- load `/api/source-keys.js` script on all pages so security keys are available

## Testing
- `node -v`
- `npm run build` *(fails: esbuild missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0b31a24832887b17b0515611865