### PR TITLE
Refactor search handlers

### DIFF
--- a/frontend/src/core/folder.js
+++ b/frontend/src/core/folder.js
@@ -1,6 +1,6 @@
 // 📁 frontend/src/folder.js
 
-import { showToast, updateFolderPaginationUI } from "./ui.js";
+import { showToast, updatePagination } from "./ui.js";
 import {
   getRootFolder,
   getSourceKey,
@@ -112,7 +112,13 @@ function renderFromData(data) {
     renderFolderGrid(pagedFolders);
 
     // 🆕 update đúng phân trang: dùng tổng số folders
-    updateFolderPaginationUI(folderPage, totalFolders, foldersPerPage);
+    updatePagination(
+      document.getElementById("app"),
+      folderPage,
+      totalFolders,
+      foldersPerPage,
+      (page) => loadFolder(state.currentPath, page)
+    );
   } else if (data.type === "reader") {
     document.getElementById("loading-overlay")?.classList.remove("hidden");
 

--- a/frontend/src/core/preload.js
+++ b/frontend/src/core/preload.js
@@ -5,20 +5,19 @@
  * @param {Array} folders - Danh sách folders từ API
  */
 export function preloadThumbnails(folders = []) {
-    const head = document.head || document.getElementsByTagName('head')[0];
-  
-    folders.forEach((folder) => {
-      if (folder.thumbnail) {
-        const link = document.createElement('link');
-        link.rel = 'preload';
-        link.as = 'image';
-        link.href = folder.thumbnail;
-  
-        // Tránh preload trùng
-        if (!head.querySelector(`link[rel="preload"][href="${folder.thumbnail}"]`)) {
-          head.appendChild(link);
-        }
+  const head = document.head || document.getElementsByTagName("head")[0];
+
+  folders.forEach((folder) => {
+    if (folder.thumbnail) {
+      const link = document.createElement("link");
+      link.rel = "preload";
+      link.as = "image";
+      link.href = folder.thumbnail;
+
+      // Tránh preload trùng
+      if (!head.querySelector(`link[rel="preload"][href="${folder.thumbnail}"]`)) {
+        head.appendChild(link);
       }
-    });
-  }
-  
+    }
+  });
+}

--- a/frontend/src/pages/movie/index.js
+++ b/frontend/src/pages/movie/index.js
@@ -1,4 +1,3 @@
-import {} from "/src/components/folderCard.js";
 import { renderFolderSlider } from "/src/components/folderSlider.js";
 import { getSourceKey } from "/src/core/storage.js";
 import { renderMovieCardWithFavorite } from "/src/components/movie/movieCard.js";
@@ -10,7 +9,9 @@ import {
   setupMovieSidebar,
   showConfirm,
   showToast,
-  toggleSidebar,withLoading
+  toggleSidebar,
+  withLoading,
+  updatePagination
 } from "/src/core/ui.js";
 import { setupGlobalClickToCloseUI } from "/src/core/events.js";
 import { getMovieCache, setMovieCache } from "/src/core/storage.js";
@@ -206,53 +207,13 @@ function loadTopVideoSlider() {
 }
 
 function updateMoviePaginationUI(currentPage, totalItems, perPage) {
-  const totalPages = Math.ceil(totalItems / perPage);
-  const app = document.getElementById("movie-app");
-
-  const nav = document.createElement("div");
-  nav.className = "reader-controls";
-
-  const prev = document.createElement("button");
-  prev.textContent = "⬅ Trang trước";
-  prev.disabled = currentPage <= 0;
-  prev.onclick = () => loadMovieFolder(currentPath, currentPage - 1);
-  nav.appendChild(prev);
-
-  const jumpForm = document.createElement("form");
-  jumpForm.style.display = "inline-block";
-  jumpForm.style.margin = "0 10px";
-  jumpForm.onsubmit = (e) => {
-    e.preventDefault();
-    const page = parseInt(jumpInput.value) - 1;
-    if (!isNaN(page) && page >= 0) loadMovieFolder(currentPath, page);
-  };
-
-  const jumpInput = document.createElement("input");
-  jumpInput.type = "number";
-  jumpInput.min = 1;
-  jumpInput.max = totalPages;
-  jumpInput.placeholder = "Trang...";
-  jumpInput.style.width = "60px";
-
-  const jumpBtn = document.createElement("button");
-  jumpBtn.textContent = "⏩";
-  jumpForm.appendChild(jumpInput);
-  jumpForm.appendChild(jumpBtn);
-  nav.appendChild(jumpForm);
-
-  const next = document.createElement("button");
-  next.textContent = "Trang sau ➡";
-  next.disabled = currentPage + 1 >= totalPages;
-  next.onclick = () => loadMovieFolder(currentPath, currentPage + 1);
-  nav.appendChild(next);
-
-  app.appendChild(nav);
-
-  const info = document.createElement("div");
-  info.textContent = `Trang ${currentPage + 1} / ${totalPages}`;
-  info.style.textAlign = "center";
-  info.style.marginTop = "10px";
-  app.appendChild(info);
+  updatePagination(
+    document.getElementById("movie-app"),
+    currentPage,
+    totalItems,
+    perPage,
+    (p) => loadMovieFolder(currentPath, p)
+  );
 }
 
 function renderRecentVideoSlider() {

--- a/frontend/src/pages/music/index.js
+++ b/frontend/src/pages/music/index.js
@@ -13,10 +13,13 @@ import {
   showToast,
   toggleSearchBar,
   setupMusicSidebar,
-  showConfirm,renderRecentViewedMusic,withLoading
+  showConfirm,
+  renderRecentViewedMusic,
+  withLoading,
+  updatePagination,
+  filterMusic,
+  buildThumbnailUrl,
 } from "/src/core/ui.js";
-import { filterMusic } from "/src/core/ui.js";
-import { buildThumbnailUrl } from "/src/core/ui.js";
 
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -245,62 +248,13 @@ function setupExtractThumbnailButton() {
 
 // Thêm giao diện phân trang cho danh sách nhạc
 function updateMusicPaginationUI(currentPage, totalItems, perPage) {
-  const totalPages = Math.ceil(totalItems / perPage);
-  const app = document.getElementById("music-app");
-
-  // Xoá control cũ nếu có
-  const oldControls = app.querySelector(".reader-controls");
-  if (oldControls) oldControls.remove();
-  const oldInfo = app.querySelector(".music-pagination-info");
-  if (oldInfo) oldInfo.remove();
-
-  // Tạo control chuyển trang
-  const nav = document.createElement("div");
-  nav.className = "reader-controls";
-
-  const prev = document.createElement("button");
-  prev.textContent = "⬅ Trang trước";
-  prev.disabled = currentPage <= 0;
-  prev.onclick = () => loadMusicFolder(currentPath, currentPage - 1);
-  nav.appendChild(prev);
-
-  const jumpForm = document.createElement("form");
-  jumpForm.style.display = "inline-block";
-  jumpForm.style.margin = "0 10px";
-  jumpForm.onsubmit = (e) => {
-    e.preventDefault();
-    const page = parseInt(jumpInput.value) - 1;
-    if (!isNaN(page) && page >= 0) loadMusicFolder(currentPath, page);
-  };
-
-  const jumpInput = document.createElement("input");
-  jumpInput.type = "number";
-  jumpInput.min = 1;
-  jumpInput.max = totalPages;
-  jumpInput.placeholder = "Trang...";
-  jumpInput.style.width = "60px";
-
-  const jumpBtn = document.createElement("button");
-  jumpBtn.textContent = "⏩";
-  jumpForm.appendChild(jumpInput);
-  jumpForm.appendChild(jumpBtn);
-  nav.appendChild(jumpForm);
-
-  const next = document.createElement("button");
-  next.textContent = "Trang sau ➡";
-  next.disabled = currentPage + 1 >= totalPages;
-  next.onclick = () => loadMusicFolder(currentPath, currentPage + 1);
-  nav.appendChild(next);
-
-  app.appendChild(nav);
-
-  // Thêm info số trang
-  const info = document.createElement("div");
-  info.textContent = `Trang ${currentPage + 1} / ${totalPages}`;
-  info.className = "music-pagination-info";
-  info.style.textAlign = "center";
-  info.style.marginTop = "10px";
-  app.appendChild(info);
+  updatePagination(
+    document.getElementById("music-app"),
+    currentPage,
+    totalItems,
+    perPage,
+    (p) => loadMusicFolder(currentPath, p)
+  );
 }
 
 // 👉 Tải slider danh sách Playlist


### PR DESCRIPTION
## Summary
- deduplicate search logic in `ui.js`
- clean up `preload.js`
- consolidate pagination into a reusable `updatePagination` helper

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684ee4ead8848328bf5d6cb6e596bb0f