### PR TITLE
Improve media card responsiveness

### DIFF
--- a/frontend/src/styles/components/folder-card.css
+++ b/frontend/src/styles/components/folder-card.css
@@ -101,24 +101,38 @@
   padding: 0 16px;
 }
 
-/* SLIDER – trên mobile vẫn cần resize */
 @media (max-width: 768px) {
-  .folder-section.slider .folder-card {
-    width: 140px;
-  }
-
-  .folder-section.slider .folder-thumb {
-    height: 200px;
+  .folder-section.grid .grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
   }
 }
 
 @media (max-width: 480px) {
+  .folder-section.grid .grid {
+    grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+    gap: 8px;
+  }
+}
+
+/* SLIDER – trên mobile vẫn cần resize */
+@media (max-width: 768px) {
   .folder-section.slider .folder-card {
     width: 120px;
   }
 
   .folder-section.slider .folder-thumb {
-    height: 180px;
+    height: 160px;
+  }
+}
+
+@media (max-width: 480px) {
+  .folder-section.slider .folder-card {
+    width: 90px;
+  }
+
+  .folder-section.slider .folder-thumb {
+    height: 120px;
   }
 }
 

--- a/frontend/src/styles/components/folder-slider.css
+++ b/frontend/src/styles/components/folder-slider.css
@@ -217,22 +217,30 @@
   .nav-button.next-button {
     right: -5px;
   }
-  
+
   @media (max-width: 768px) {
-    .folder-card {
-      width: 140px;
+    .slider-wrapper {
+      gap: 12px;
+      padding: 8px 12px;
     }
-    .folder-thumb {
-      height: 200px;
-    }
-  }
-  
-  @media (max-width: 480px) {
     .folder-card {
       width: 120px;
     }
     .folder-thumb {
-      height: 180px;
+      height: 160px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .slider-wrapper {
+      gap: 8px;
+      padding: 8px;
+    }
+    .folder-card {
+      width: 90px;
+    }
+    .folder-thumb {
+      height: 120px;
     }
   }
 

--- a/frontend/src/styles/components/movie/movie-card.css
+++ b/frontend/src/styles/components/movie/movie-card.css
@@ -58,3 +58,17 @@
   gap: 20px;
   margin-top: 32px;
 }
+
+@media (max-width: 768px) {
+  .movie-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .movie-grid {
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 12px;
+  }
+}

--- a/frontend/src/styles/components/music/music-card.css
+++ b/frontend/src/styles/components/music/music-card.css
@@ -133,7 +133,7 @@
 
 @media (max-width: 600px) {
   .music-grid {
-    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
     gap: 8px;
   }
   .music-card {


### PR DESCRIPTION
## Summary
- scale down folder cards and grids on small screens to avoid overflow
- tighten slider spacing and padding for better mobile layout
- update movie and music grids to use smaller columns on phones

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a49f2f0f548328a9063830ef7f5cac