### PR TITLE
Improve responsive layout for media home pages

### DIFF
--- a/react-app/src/pages/manga/MangaHome.jsx
+++ b/react-app/src/pages/manga/MangaHome.jsx
@@ -526,7 +526,7 @@ const MangaHome = () => {
         </div>
       ) : viewMode === 'grid' ? (
         <>
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3 sm:gap-4">
           {pageItems.map((item, index) => (
             <MangaCard
               key={`${item.path || item.name || index}-${localRefreshTrigger}`}

--- a/react-app/src/pages/movie/MovieHome.jsx
+++ b/react-app/src/pages/movie/MovieHome.jsx
@@ -368,10 +368,10 @@ const MovieHome = () => {
           <>
             {/* Current page items (after filtering & sorting) */}
             <div className={`grid ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5' 
+              viewMode === 'grid'
+                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
                 : 'grid-cols-1'
-            } gap-6 mb-8`}>
+            } gap-4 md:gap-6 mb-8`}>
               {currentMovies.map((movie) => (
                 <MovieCard
                   key={movie.path}

--- a/react-app/src/pages/music/MusicHome.jsx
+++ b/react-app/src/pages/music/MusicHome.jsx
@@ -364,7 +364,7 @@ const MusicHome = () => {
         </div>
 
         {/* Statistics cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 sm:gap-4 mb-8">
           <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center">
               <FiMusic className="w-8 h-8 text-blue-500 mr-3" />
@@ -452,9 +452,9 @@ const MusicHome = () => {
           </div>
         ) : (
           <>
-            <div className={`grid gap-4 ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6' 
+            <div className={`grid gap-3 sm:gap-4 ${
+              viewMode === 'grid'
+                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6'
                 : 'grid-cols-1'
             }`}>
               {currentMusic.map((music, index) => (

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -14,8 +14,8 @@
 .embla__container {
   display: flex;
   align-items: flex-start;
-  gap: var(--slide-spacing, 0.75rem);
-  padding: 0 var(--slide-spacing, 0.75rem);
+  gap: var(--slide-spacing, 0.5rem);
+  padding: 0;
 }
 
 .embla__slide {
@@ -27,8 +27,8 @@
 /* Responsive slide widths */
 @media (max-width: 640px) {
   .embla__slide {
-    flex: 0 0 50%;
-    max-width: 50%;
+    flex: 0 0 calc(50% - var(--slide-spacing, 0.5rem) / 2);
+    max-width: calc(50% - var(--slide-spacing, 0.5rem) / 2);
   }
 }
 

--- a/react-app/src/styles/components/manga-card.css
+++ b/react-app/src/styles/components/manga-card.css
@@ -159,7 +159,7 @@
 
 /* Slider variant */
 .manga-card.slider {
-  width: 160px;
+  width: min(45vw, 160px);
   flex-shrink: 0;
 }
 
@@ -202,21 +202,17 @@
 
 /* Mobile responsive */
 @media (max-width: 640px) {
-  .manga-card.slider {
-    width: 140px;
-  }
-  
   .manga-card-title {
     padding: 0.5rem;
     font-size: 0.75rem;
   }
-  
+
   .view-count-badge {
     font-size: 0.625rem;
     padding: 0.2rem 0.4rem;
     gap: 0.125rem;
   }
-  
+
   .view-count-badge svg {
     width: 0.625rem;
     height: 0.625rem;


### PR DESCRIPTION
## Summary
- Scale slider cards with viewport and trim carousel gaps to prevent overflow
- Tighten mobile grid spacing for manga, movie, and music listings

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f2f0f548328a9063830ef7f5cac