### PR TITLE
fix: responsive slider cards on mobile

### DIFF
--- a/react-app/src/components/common/Layout.jsx
+++ b/react-app/src/components/common/Layout.jsx
@@ -51,7 +51,8 @@ const Layout = () => {
         </AnimatePresence>
 
         <main className="flex-1 transition-all duration-200">
-          <div className="container mx-auto px-4 py-6">
+          {/* 🛡️ Thêm overflow-x-hidden để tránh nội dung tràn ngang ngoài khung chính */}
+          <div className="container mx-auto px-4 py-6 overflow-x-hidden">
             <Outlet />
           </div>
         </main>

--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -302,7 +302,8 @@ const RandomSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* 🔄 Khung chờ tỷ lệ 3:4 chiếm toàn bộ chiều rộng slide */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -318,7 +319,7 @@ const RandomSlider = ({
                       await handleToggleFavorite(toggleItem);
                     }}
                     variant="compact"
-                    className="w-48"
+                    className="w-full" /* 📱 Toàn bộ chiều rộng slide để responsive */
                   />
                 </div>
               ))

--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -232,7 +232,11 @@ const RandomSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Wrapper w-full + overflow-hidden để tránh tràn ngang trên mobile
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -318,7 +318,7 @@ const RandomSlider = ({
                     onToggleFavorite={async (toggleItem) => {
                       await handleToggleFavorite(toggleItem);
                     }}
-                    variant="compact"
+                    variant="slider"
                     className="w-full" /* 📱 Toàn bộ chiều rộng slide để responsive */
                   />
                 </div>

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -275,7 +275,11 @@ const RecentSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Bao slider bằng w-full + overflow-hidden để tránh vượt quá màn hình
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -371,7 +371,8 @@ const RecentSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* ⏳ Khung chờ tỷ lệ 3:4, full width để tránh tràn */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -397,7 +398,7 @@ const RecentSlider = ({
                       onToggleFavorite={async (toggleItem) => {
                         await handleToggleFavorite(toggleItem);
                       }}
-                      className="w-48"
+                      className="w-full" /* 📱 Chiếm full chiều rộng slide */
                     />
                   </div>
                 </div>

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -280,7 +280,7 @@ const TopViewSlider = ({
                       isFavorite={Boolean(item.isFavorite)}
                       showViews={true}
                       onToggleFavorite={() => handleToggleFavorite(item)}
-                      variant="compact"
+                      variant="slider"
                       className="w-full" /* 📱 Card full width để responsive */
                       overlayMode={type === 'manga' ? 'views' : 'type'}
                     />

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -251,7 +251,8 @@ const TopViewSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* ⏳ Skeleton tỷ lệ 3:4 toàn chiều rộng slide */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -280,7 +281,7 @@ const TopViewSlider = ({
                       showViews={true}
                       onToggleFavorite={() => handleToggleFavorite(item)}
                       variant="compact"
-                      className="w-48"
+                      className="w-full" /* 📱 Card full width để responsive */
                       overlayMode={type === 'manga' ? 'views' : 'type'}
                     />
                   </div>

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -194,7 +194,11 @@ const TopViewSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Gắn w-full và overflow-hidden để container không kéo rộng body
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/UniversalCard.jsx
+++ b/react-app/src/components/common/UniversalCard.jsx
@@ -211,7 +211,7 @@ const UniversalCard = ({
   const cardVariants = {
     default: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200',
     compact: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200',
-    slider: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200'
+    slider: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 w-full max-w-[160px] sm:max-w-[200px]'
   };
 
   // Aspect ratio based on type
@@ -320,8 +320,12 @@ const UniversalCard = ({
       </div>
 
       {/* Content */}
-      <div className="p-3">
-        <h3 className="font-medium text-gray-900 dark:text-white text-sm line-clamp-2 mb-1">
+      <div className={variant === 'slider' ? 'p-2' : 'p-3'}>
+        <h3
+          className={`font-medium text-gray-900 dark:text-white line-clamp-2 mb-1 ${
+            type === 'music' ? 'text-base' : 'text-sm'
+          }`}
+        >
           {itemData.displayName}
         </h3>
         

--- a/react-app/src/components/manga/MangaRandomSection.jsx
+++ b/react-app/src/components/manga/MangaRandomSection.jsx
@@ -16,7 +16,7 @@ const MangaRandomSection = () => {
 
   return (
     // 🛡️ Bao các slider bằng w-full + overflow-hidden, thêm px-2 trên mobile để có đệm lề
-    <div className="manga-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
+  <div className="manga-random-sections space-y-6 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-screen-lg lg:max-w-screen-xl mx-auto overflow-x-hidden px-1 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="manga"

--- a/react-app/src/components/manga/MangaRandomSection.jsx
+++ b/react-app/src/components/manga/MangaRandomSection.jsx
@@ -15,7 +15,8 @@ const MangaRandomSection = () => {
   }
 
   return (
-    <div className="manga-random-sections space-y-6">
+    // 🛡️ Bao các slider bằng w-full + overflow-hidden để tránh tràn
+    <div className="manga-random-sections space-y-6 w-full overflow-hidden">
       {/* Random Banner */}
       <RandomSlider
         type="manga"

--- a/react-app/src/components/manga/MangaRandomSection.jsx
+++ b/react-app/src/components/manga/MangaRandomSection.jsx
@@ -15,8 +15,8 @@ const MangaRandomSection = () => {
   }
 
   return (
-    // 🛡️ Bao các slider bằng w-full + overflow-hidden để tránh tràn
-    <div className="manga-random-sections space-y-6 w-full overflow-hidden">
+    // 🛡️ Bao các slider bằng w-full + overflow-hidden, thêm px-2 trên mobile để có đệm lề
+    <div className="manga-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="manga"

--- a/react-app/src/components/movie/MovieRandomSection.jsx
+++ b/react-app/src/components/movie/MovieRandomSection.jsx
@@ -16,8 +16,8 @@ const MovieRandomSection = () => {
   }
 
   return (
-    // 🛡️ Đảm bảo vùng random không gây tràn ngang
-    <div className="movie-random-sections space-y-6 w-full overflow-hidden">
+    // 🛡️ Đảm bảo vùng random không gây tràn ngang, thêm px-2 cho mobile
+    <div className="movie-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="movie"

--- a/react-app/src/components/movie/MovieRandomSection.jsx
+++ b/react-app/src/components/movie/MovieRandomSection.jsx
@@ -16,7 +16,8 @@ const MovieRandomSection = () => {
   }
 
   return (
-    <div className="movie-random-sections space-y-6">
+    // 🛡️ Đảm bảo vùng random không gây tràn ngang
+    <div className="movie-random-sections space-y-6 w-full overflow-hidden">
       {/* Random Banner */}
       <RandomSlider
         type="movie"

--- a/react-app/src/components/music/MusicCard.jsx
+++ b/react-app/src/components/music/MusicCard.jsx
@@ -146,7 +146,7 @@ const MusicCard = ({
 
       {/* Content */}
       <div className="p-3">
-        <h3 className="font-medium text-gray-900 dark:text-white text-sm line-clamp-2 mb-1">
+        <h3 className="font-medium text-gray-900 dark:text-white text-base line-clamp-2 mb-1">
           {displayName}
         </h3>
         

--- a/react-app/src/components/music/MusicRandomSection.jsx
+++ b/react-app/src/components/music/MusicRandomSection.jsx
@@ -25,7 +25,7 @@ const MusicRandomSection = () => {
         autoplay={true}
         showRefresh={true}
         showTimestamp={true}
-        className="music-random-banner"
+        className="music-random-banner px-2 sm:px-0"
       />
       
       {/* Top View - using dedicated TopViewSlider */}
@@ -33,7 +33,7 @@ const MusicRandomSection = () => {
         type="music"
         title="🔥 Most Played"
         autoplay={false}
-        className="music-top-view"
+        className="music-top-view px-2 sm:px-0"
       />
 
       {/* Recent Viewed */}
@@ -44,7 +44,7 @@ const MusicRandomSection = () => {
         showRefresh={false}
         showTimestamp={true}
         maxItems={15}
-        className="music-recent-view"
+        className="music-recent-view px-2 sm:px-0"
       />
     </div>
   );

--- a/react-app/src/components/music/MusicRandomSection.jsx
+++ b/react-app/src/components/music/MusicRandomSection.jsx
@@ -16,8 +16,8 @@ const MusicRandomSection = () => {
   }
 
   return (
-    // 🛡️ Section bao quanh có w-full + overflow-hidden để không tạo scroll ngang
-    <div className="music-random-sections space-y-6 w-full overflow-hidden">
+    // 🛡️ Section bao quanh có w-full + overflow-hidden, thêm px-2 cho mobile để tránh tràn lề
+    <div className="music-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="music"
@@ -26,7 +26,7 @@ const MusicRandomSection = () => {
         autoplay={true}
         showRefresh={true}
         showTimestamp={true}
-        className="music-random-banner px-2 sm:px-0"
+        className="music-random-banner"
       />
       
       {/* Top View - using dedicated TopViewSlider */}
@@ -34,7 +34,7 @@ const MusicRandomSection = () => {
         type="music"
         title="🔥 Most Played"
         autoplay={false}
-        className="music-top-view px-2 sm:px-0"
+        className="music-top-view"
       />
 
       {/* Recent Viewed */}
@@ -45,7 +45,7 @@ const MusicRandomSection = () => {
         showRefresh={false}
         showTimestamp={true}
         maxItems={15}
-        className="music-recent-view px-2 sm:px-0"
+        className="music-recent-view"
       />
     </div>
   );

--- a/react-app/src/components/music/MusicRandomSection.jsx
+++ b/react-app/src/components/music/MusicRandomSection.jsx
@@ -16,7 +16,8 @@ const MusicRandomSection = () => {
   }
 
   return (
-    <div className="music-random-sections space-y-6">
+    // 🛡️ Section bao quanh có w-full + overflow-hidden để không tạo scroll ngang
+    <div className="music-random-sections space-y-6 w-full overflow-hidden">
       {/* Random Banner */}
       <RandomSlider
         type="music"

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -44,6 +44,8 @@
 
 html {
   scroll-behavior: smooth;
+  /* 🛡️ Ẩn tràn ngang toàn cục để slider/grid không làm rộng màn hình */
+  overflow-x: hidden;
 }
 
 body {
@@ -54,6 +56,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease-in-out;
+  /* 🛡️ Tiếp tục khóa tràn ngang ở body để tránh xuất hiện thanh scroll ngang */
+  overflow-x: hidden;
 }
 
 /* Dark mode */

--- a/react-app/src/pages/manga/MangaHome.jsx
+++ b/react-app/src/pages/manga/MangaHome.jsx
@@ -319,7 +319,7 @@ const MangaHome = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center overflow-x-hidden">
         <div className="text-center">
           <Loader className="w-8 h-8 animate-spin text-blue-500 mx-auto mb-4" />
           <p className="text-gray-600 dark:text-gray-400">Đang tải danh sách manga...</p>
@@ -330,7 +330,7 @@ const MangaHome = () => {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center overflow-x-hidden">
         <div className="text-center">
           <p className="text-red-500 mb-4">Lỗi: {error}</p>
           <Button onClick={() => fetchMangaFolders(currentPath)}>
@@ -342,7 +342,8 @@ const MangaHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+    // 🛡️ overflow-x-hidden để ngăn card/slider kéo rộng ngoài màn hình
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6 overflow-x-hidden">
   {/* Random Sections - chỉ hiển thị ở root để giảm tải khi quay lại từ Reader */}
   {showRandomSection && <MangaRandomSection />}
       
@@ -526,7 +527,8 @@ const MangaHome = () => {
         </div>
       ) : viewMode === 'grid' ? (
         <>
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        {/* 🔒 Lưới chính: w-full + overflow-hidden để không kéo rộng trang */}
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 w-full overflow-hidden">
           {pageItems.map((item, index) => (
             <MangaCard
               key={`${item.path || item.name || index}-${localRefreshTrigger}`}

--- a/react-app/src/pages/manga/MangaHome.jsx
+++ b/react-app/src/pages/manga/MangaHome.jsx
@@ -342,8 +342,8 @@ const MangaHome = () => {
   }
 
   return (
-    // 🛡️ overflow-x-hidden để ngăn card/slider kéo rộng ngoài màn hình
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6 overflow-x-hidden">
+  // 🛡️ overflow-x-hidden để ngăn card/slider kéo rộng ngoài màn hình
+  <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-2 sm:p-6 overflow-x-hidden">
   {/* Random Sections - chỉ hiển thị ở root để giảm tải khi quay lại từ Reader */}
   {showRandomSection && <MangaRandomSection />}
       
@@ -526,9 +526,9 @@ const MangaHome = () => {
           </p>
         </div>
       ) : viewMode === 'grid' ? (
-        <>
-        {/* 🔒 Lưới chính: w-full + overflow-hidden để không kéo rộng trang */}
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 w-full overflow-hidden">
+  <>
+  {/* 🔒 Lưới chính: w-full + overflow-hidden để không kéo rộng trang */}
+  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 sm:gap-4 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-screen-lg lg:max-w-screen-xl mx-auto overflow-x-hidden px-1 sm:px-0">
           {pageItems.map((item, index) => (
             <MangaCard
               key={`${item.path || item.name || index}-${localRefreshTrigger}`}

--- a/react-app/src/pages/movie/MovieHome.jsx
+++ b/react-app/src/pages/movie/MovieHome.jsx
@@ -208,7 +208,8 @@ const MovieHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    // 🛡️ Tránh slider/grid làm body rộng hơn bằng overflow-x-hidden
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
       {/* Random Sections - First */}
       <div className="bg-gray-50 dark:bg-gray-900 py-6">
         <div className="w-full px-6">
@@ -367,11 +368,14 @@ const MovieHome = () => {
         ) : (
           <>
             {/* Current page items (after filtering & sorting) */}
-            <div className={`grid ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5' 
-                : 'grid-cols-1'
-            } gap-6 mb-8`}>
+            {/* 🔒 w-full + overflow-hidden để lưới phim không vượt quá màn hình */}
+            <div
+              className={`grid w-full overflow-hidden ${
+                viewMode === 'grid'
+                  ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
+                  : 'grid-cols-1'
+              } gap-6 mb-8`}
+            >
               {currentMovies.map((movie) => (
                 <MovieCard
                   key={movie.path}

--- a/react-app/src/pages/music/MusicHome.jsx
+++ b/react-app/src/pages/music/MusicHome.jsx
@@ -231,7 +231,8 @@ const MusicHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    // 🛡️ overflow-x-hidden để tránh các section kéo rộng body trên mobile
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
       {/* Random slider: always show (kept when navigating folders) */}
       <div className="mb-8">
         <MusicRandomSection />
@@ -452,11 +453,14 @@ const MusicHome = () => {
           </div>
         ) : (
           <>
-            <div className={`grid gap-4 ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6' 
-                : 'grid-cols-1'
-            }`}>
+            {/* 🔒 w-full + overflow-hidden tránh lưới tràn ngang */}
+            <div
+              className={`grid gap-4 w-full overflow-hidden ${
+                viewMode === 'grid'
+                  ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6'
+                  : 'grid-cols-1'
+              }`}
+            >
               {currentMusic.map((music, index) => (
                 <MusicCard
                   key={music.path || index}

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -28,41 +28,41 @@
 /* Responsive slide widths */
 @media (max-width: 640px) {
   .embla__slide {
-    /* 📱 Hai slide mỗi hàng, trừ khoảng cách để không tràn */
-    flex: 0 0 calc((100% - var(--slide-spacing, 0.75rem)) / 2);
-    max-width: calc((100% - var(--slide-spacing, 0.75rem)) / 2);
+    /* 📱 Hai slide mỗi hàng, trừ 3 khoảng cách (2 padding + 1 gap) */
+    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 2);
+    max-width: calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 2);
   }
 }
 
 @media (min-width: 641px) and (max-width: 768px) {
   .embla__slide {
-    /* 📱 Ba slide mỗi hàng với gap cân đối */
-    flex: 0 0 calc((100% - 2 * var(--slide-spacing, 0.75rem)) / 3);
-    max-width: calc((100% - 2 * var(--slide-spacing, 0.75rem)) / 3);
+    /* 📱 Ba slide mỗi hàng, trừ 4 khoảng cách (2 padding + 2 gap) */
+    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 3);
+    max-width: calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 3);
   }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
   .embla__slide {
-    /* 💻 Bốn slide mỗi hàng */
-    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 4);
-    max-width: calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 4);
+    /* 💻 Bốn slide mỗi hàng, trừ 5 khoảng cách */
+    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 4);
+    max-width: calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 4);
   }
 }
 
 @media (min-width: 1025px) and (max-width: 1280px) {
   .embla__slide {
-    /* 🖥️ Năm slide mỗi hàng */
-    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 5);
-    max-width: calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 5);
+    /* 🖥️ Năm slide mỗi hàng, trừ 6 khoảng cách */
+    flex: 0 0 calc((100% - 6 * var(--slide-spacing, 0.75rem)) / 5);
+    max-width: calc((100% - 6 * var(--slide-spacing, 0.75rem)) / 5);
   }
 }
 
 @media (min-width: 1281px) {
   .embla__slide {
-    /* 🖥️🖥️ Sáu slide mỗi hàng */
-    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 6);
-    max-width: calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 6);
+    /* 🖥️🖥️ Sáu slide mỗi hàng, trừ 7 khoảng cách */
+    flex: 0 0 calc((100% - 7 * var(--slide-spacing, 0.75rem)) / 6);
+    max-width: calc((100% - 7 * var(--slide-spacing, 0.75rem)) / 6);
   }
 }
 

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -15,8 +15,8 @@
 .embla__container {
   display: flex;
   align-items: flex-start;
-  gap: var(--slide-spacing, 0.75rem);
-  padding: 0 var(--slide-spacing, 0.75rem);
+  gap: var(--slide-spacing, 0.5rem);
+  padding: 0 var(--slide-spacing, 0.5rem);
 }
 
 .embla__slide {
@@ -29,40 +29,40 @@
 @media (max-width: 640px) {
   .embla__slide {
     /* 📱 Hai slide mỗi hàng, trừ 3 khoảng cách (2 padding + 1 gap) */
-    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 2);
-    max-width: calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 2);
+    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.5rem)) / 2);
+    max-width: calc((100% - 3 * var(--slide-spacing, 0.5rem)) / 2);
   }
 }
 
 @media (min-width: 641px) and (max-width: 768px) {
   .embla__slide {
     /* 📱 Ba slide mỗi hàng, trừ 4 khoảng cách (2 padding + 2 gap) */
-    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 3);
-    max-width: calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 3);
+    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.5rem)) / 3);
+    max-width: calc((100% - 4 * var(--slide-spacing, 0.5rem)) / 3);
   }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
   .embla__slide {
     /* 💻 Bốn slide mỗi hàng, trừ 5 khoảng cách */
-    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 4);
-    max-width: calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 4);
+    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.5rem)) / 4);
+    max-width: calc((100% - 5 * var(--slide-spacing, 0.5rem)) / 4);
   }
 }
 
 @media (min-width: 1025px) and (max-width: 1280px) {
   .embla__slide {
     /* 🖥️ Năm slide mỗi hàng, trừ 6 khoảng cách */
-    flex: 0 0 calc((100% - 6 * var(--slide-spacing, 0.75rem)) / 5);
-    max-width: calc((100% - 6 * var(--slide-spacing, 0.75rem)) / 5);
+    flex: 0 0 calc((100% - 6 * var(--slide-spacing, 0.5rem)) / 5);
+    max-width: calc((100% - 6 * var(--slide-spacing, 0.5rem)) / 5);
   }
 }
 
 @media (min-width: 1281px) {
   .embla__slide {
     /* 🖥️🖥️ Sáu slide mỗi hàng, trừ 7 khoảng cách */
-    flex: 0 0 calc((100% - 7 * var(--slide-spacing, 0.75rem)) / 6);
-    max-width: calc((100% - 7 * var(--slide-spacing, 0.75rem)) / 6);
+    flex: 0 0 calc((100% - 7 * var(--slide-spacing, 0.5rem)) / 6);
+    max-width: calc((100% - 7 * var(--slide-spacing, 0.5rem)) / 6);
   }
 }
 

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -11,6 +11,7 @@
   width: 100%;
 }
 
+/* 📦 Container flex có khoảng cách giữa các slide và padding hai bên */
 .embla__container {
   display: flex;
   align-items: flex-start;
@@ -27,36 +28,41 @@
 /* Responsive slide widths */
 @media (max-width: 640px) {
   .embla__slide {
-    flex: 0 0 50%;
-    max-width: 50%;
+    /* 📱 Hai slide mỗi hàng, trừ khoảng cách để không tràn */
+    flex: 0 0 calc((100% - var(--slide-spacing, 0.75rem)) / 2);
+    max-width: calc((100% - var(--slide-spacing, 0.75rem)) / 2);
   }
 }
 
 @media (min-width: 641px) and (max-width: 768px) {
   .embla__slide {
-    flex: 0 0 33.333333%;
-    max-width: 33.333333%;
+    /* 📱 Ba slide mỗi hàng với gap cân đối */
+    flex: 0 0 calc((100% - 2 * var(--slide-spacing, 0.75rem)) / 3);
+    max-width: calc((100% - 2 * var(--slide-spacing, 0.75rem)) / 3);
   }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
   .embla__slide {
-    flex: 0 0 25%;
-    max-width: 25%;
+    /* 💻 Bốn slide mỗi hàng */
+    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 4);
+    max-width: calc((100% - 3 * var(--slide-spacing, 0.75rem)) / 4);
   }
 }
 
 @media (min-width: 1025px) and (max-width: 1280px) {
   .embla__slide {
-    flex: 0 0 20%;
-    max-width: 20%;
+    /* 🖥️ Năm slide mỗi hàng */
+    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 5);
+    max-width: calc((100% - 4 * var(--slide-spacing, 0.75rem)) / 5);
   }
 }
 
 @media (min-width: 1281px) {
   .embla__slide {
-    flex: 0 0 16.666667%;
-    max-width: 16.666667%;
+    /* 🖥️🖥️ Sáu slide mỗi hàng */
+    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 6);
+    max-width: calc((100% - 5 * var(--slide-spacing, 0.75rem)) / 6);
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent mobile carousel overflow by letting cards span slide width
- adjust embla slide widths to account for gaps across breakpoints

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a9403f02588328975d5744c11960c8