### PR TITLE
fix: responsive slider cards on mobile

### DIFF
--- a/react-app/src/components/common/Breadcrumb.jsx
+++ b/react-app/src/components/common/Breadcrumb.jsx
@@ -9,7 +9,11 @@ const Breadcrumb = ({ items = [], onNavigate, className = '' }) => {
   if (!items || items.length === 0) return null;
 
   return (
-    <nav className={`flex items-center space-x-2 text-sm ${className}`} aria-label="Breadcrumb">
+    {/* 🧭 Nav chứa breadcrumb với khả năng xuống dòng khi hẹp */}
+    <nav
+      className={`flex flex-wrap items-center gap-2 text-sm ${className}`}
+      aria-label="Breadcrumb"
+    >
       {items.map((item, index) => (
         <React.Fragment key={item.path || index}>
           {index > 0 && (

--- a/react-app/src/components/common/Breadcrumb.jsx
+++ b/react-app/src/components/common/Breadcrumb.jsx
@@ -9,11 +9,11 @@ const Breadcrumb = ({ items = [], onNavigate, className = '' }) => {
   if (!items || items.length === 0) return null;
 
   return (
-    {/* 🧭 Nav chứa breadcrumb với khả năng xuống dòng khi hẹp */}
     <nav
       className={`flex flex-wrap items-center gap-2 text-sm ${className}`}
       aria-label="Breadcrumb"
     >
+      {/* 🧭 Nav chứa breadcrumb với khả năng xuống dòng khi hẹp */}
       {items.map((item, index) => (
         <React.Fragment key={item.path || index}>
           {index > 0 && (

--- a/react-app/src/components/common/Layout.jsx
+++ b/react-app/src/components/common/Layout.jsx
@@ -51,7 +51,8 @@ const Layout = () => {
         </AnimatePresence>
 
         <main className="flex-1 transition-all duration-200">
-          <div className="container mx-auto px-4 py-6">
+          {/* 🛡️ Thêm overflow-x-hidden để tránh nội dung tràn ngang ngoài khung chính */}
+          <div className="container mx-auto px-4 py-6 overflow-x-hidden">
             <Outlet />
           </div>
         </main>

--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -232,7 +232,11 @@ const RandomSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Wrapper w-full + overflow-hidden để tránh tràn ngang trên mobile
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">
@@ -302,7 +306,8 @@ const RandomSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* 🔄 Khung chờ tỷ lệ 3:4 chiếm toàn bộ chiều rộng slide */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -317,8 +322,8 @@ const RandomSlider = ({
                     onToggleFavorite={async (toggleItem) => {
                       await handleToggleFavorite(toggleItem);
                     }}
-                    variant="compact"
-                    className="w-48"
+                    variant="slider"
+                    className="w-full" /* 📱 Toàn bộ chiều rộng slide để responsive */
                   />
                 </div>
               ))

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -275,7 +275,11 @@ const RecentSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Bao slider bằng w-full + overflow-hidden để tránh vượt quá màn hình
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">
@@ -371,7 +375,8 @@ const RecentSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* ⏳ Khung chờ tỷ lệ 3:4, full width để tránh tràn */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -397,7 +402,7 @@ const RecentSlider = ({
                       onToggleFavorite={async (toggleItem) => {
                         await handleToggleFavorite(toggleItem);
                       }}
-                      className="w-48"
+                      className="w-full" /* 📱 Chiếm full chiều rộng slide */
                     />
                   </div>
                 </div>

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -194,7 +194,11 @@ const TopViewSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    // 🛡️ Gắn w-full và overflow-hidden để container không kéo rộng body
+    <div
+      ref={containerRef}
+      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 w-full overflow-hidden ${className}`}
+    >
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">
@@ -251,7 +255,8 @@ const TopViewSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  {/* ⏳ Skeleton tỷ lệ 3:4 toàn chiều rộng slide */}
+                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full aspect-[3/4]" />
                 </div>
               ))
             ) : (
@@ -279,8 +284,8 @@ const TopViewSlider = ({
                       isFavorite={Boolean(item.isFavorite)}
                       showViews={true}
                       onToggleFavorite={() => handleToggleFavorite(item)}
-                      variant="compact"
-                      className="w-48"
+                      variant="slider"
+                      className="w-full" /* 📱 Card full width để responsive */
                       overlayMode={type === 'manga' ? 'views' : 'type'}
                     />
                   </div>

--- a/react-app/src/components/common/UniversalCard.jsx
+++ b/react-app/src/components/common/UniversalCard.jsx
@@ -211,7 +211,7 @@ const UniversalCard = ({
   const cardVariants = {
     default: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200',
     compact: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200',
-    slider: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200'
+    slider: 'bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 w-full max-w-[160px] sm:max-w-[200px]'
   };
 
   // Aspect ratio based on type
@@ -320,8 +320,12 @@ const UniversalCard = ({
       </div>
 
       {/* Content */}
-      <div className="p-3">
-        <h3 className="font-medium text-gray-900 dark:text-white text-sm line-clamp-2 mb-1">
+      <div className={variant === 'slider' ? 'p-2' : 'p-3'}>
+        <h3
+          className={`font-medium text-gray-900 dark:text-white line-clamp-2 mb-1 ${
+            type === 'music' ? 'text-base' : 'text-sm'
+          }`}
+        >
           {itemData.displayName}
         </h3>
         

--- a/react-app/src/components/manga/MangaRandomSection.jsx
+++ b/react-app/src/components/manga/MangaRandomSection.jsx
@@ -15,7 +15,8 @@ const MangaRandomSection = () => {
   }
 
   return (
-    <div className="manga-random-sections space-y-6">
+    // 🛡️ Bao các slider bằng w-full + overflow-hidden, thêm px-2 trên mobile để có đệm lề
+    <div className="manga-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="manga"

--- a/react-app/src/components/movie/MovieRandomSection.jsx
+++ b/react-app/src/components/movie/MovieRandomSection.jsx
@@ -16,7 +16,8 @@ const MovieRandomSection = () => {
   }
 
   return (
-    <div className="movie-random-sections space-y-6">
+    // 🛡️ Đảm bảo vùng random không gây tràn ngang, thêm px-2 cho mobile
+    <div className="movie-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="movie"

--- a/react-app/src/components/music/MusicCard.jsx
+++ b/react-app/src/components/music/MusicCard.jsx
@@ -146,7 +146,7 @@ const MusicCard = ({
 
       {/* Content */}
       <div className="p-3">
-        <h3 className="font-medium text-gray-900 dark:text-white text-sm line-clamp-2 mb-1">
+        <h3 className="font-medium text-gray-900 dark:text-white text-base line-clamp-2 mb-1">
           {displayName}
         </h3>
         

--- a/react-app/src/components/music/MusicRandomSection.jsx
+++ b/react-app/src/components/music/MusicRandomSection.jsx
@@ -16,7 +16,8 @@ const MusicRandomSection = () => {
   }
 
   return (
-    <div className="music-random-sections space-y-6">
+    // 🛡️ Section bao quanh có w-full + overflow-hidden, thêm px-2 cho mobile để tránh tràn lề
+    <div className="music-random-sections space-y-6 w-full overflow-hidden px-2 sm:px-0">
       {/* Random Banner */}
       <RandomSlider
         type="music"

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -44,6 +44,8 @@
 
 html {
   scroll-behavior: smooth;
+  /* 🛡️ Ẩn tràn ngang toàn cục để slider/grid không làm rộng màn hình */
+  overflow-x: hidden;
 }
 
 body {
@@ -54,6 +56,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease-in-out;
+  /* 🛡️ Tiếp tục khóa tràn ngang ở body để tránh xuất hiện thanh scroll ngang */
+  overflow-x: hidden;
 }
 
 /* Dark mode */

--- a/react-app/src/pages/manga/MangaHome.jsx
+++ b/react-app/src/pages/manga/MangaHome.jsx
@@ -319,7 +319,7 @@ const MangaHome = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center overflow-x-hidden">
         <div className="text-center">
           <Loader className="w-8 h-8 animate-spin text-blue-500 mx-auto mb-4" />
           <p className="text-gray-600 dark:text-gray-400">Đang tải danh sách manga...</p>
@@ -330,7 +330,7 @@ const MangaHome = () => {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center overflow-x-hidden">
         <div className="text-center">
           <p className="text-red-500 mb-4">Lỗi: {error}</p>
           <Button onClick={() => fetchMangaFolders(currentPath)}>
@@ -342,14 +342,17 @@ const MangaHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+    // 🛡️ overflow-x-hidden để ngăn card/slider kéo rộng ngoài màn hình
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6 overflow-x-hidden">
   {/* Random Sections - chỉ hiển thị ở root để giảm tải khi quay lại từ Reader */}
   {showRandomSection && <MangaRandomSection />}
       
       {/* Header */}
       <div className="mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-4">
+        {/* 🔧 Khối tiêu đề và breadcrumb, sắp xếp linh hoạt trên mobile */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
+          {/* 👉 Nhóm trái: nút Back và tiêu đề */}
+          <div className="flex items-start gap-4 flex-1 min-w-0">
             {currentPath && (
               <Button
                 variant="outline"
@@ -360,15 +363,16 @@ const MangaHome = () => {
                 Back
               </Button>
             )}
-            <div>
+            {/* 📚 Tiêu đề và breadcrumb */}
+            <div className="min-w-0">
               <h1 ref={headerRef} className="text-3xl font-bold text-gray-900 dark:text-white">
                 📚 Manga Library
               </h1>
-              {/* Breadcrumb UI like Movie */}
-              <nav className="flex mt-2" aria-label="Breadcrumb">
-                <ol className="inline-flex items-center space-x-1 md:space-x-3">
+              {/* 🧭 Breadcrumb có thể xuống dòng khi hẹp */}
+              <nav className="mt-2" aria-label="Breadcrumb">
+                <ol className="flex flex-wrap items-center gap-1 md:gap-3">
                   {breadcrumbItems().map((item, index) => (
-                    <li key={index} className="inline-flex items-center">
+                    <li key={index} className="flex items-center">
                       {index > 0 && (
                         <svg className="w-6 h-6 text-gray-400 mx-1" fill="currentColor" viewBox="0 0 20 20">
                           <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
@@ -398,7 +402,8 @@ const MangaHome = () => {
               </nav>
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          {/* 👉 Nhóm phải: các nút chức năng có thể xuống dòng */}
+          <div className="flex flex-wrap items-center gap-3">
             {/* Per-page selector */}
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600 dark:text-gray-300">Per page</span>
@@ -526,7 +531,8 @@ const MangaHome = () => {
         </div>
       ) : viewMode === 'grid' ? (
         <>
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        {/* 🔒 Lưới chính: w-full + overflow-hidden để không kéo rộng trang */}
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 w-full overflow-hidden">
           {pageItems.map((item, index) => (
             <MangaCard
               key={`${item.path || item.name || index}-${localRefreshTrigger}`}

--- a/react-app/src/pages/movie/MovieHome.jsx
+++ b/react-app/src/pages/movie/MovieHome.jsx
@@ -208,7 +208,8 @@ const MovieHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    // 🛡️ Tránh slider/grid làm body rộng hơn bằng overflow-x-hidden
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
       {/* Random Sections - First */}
       <div className="bg-gray-50 dark:bg-gray-900 py-6">
         <div className="w-full px-6">
@@ -219,8 +220,10 @@ const MovieHome = () => {
       {/* Header + Grid Section Combined */}
       <div className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 p-6">
         {/* Header Controls */}
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-4">
+        {/* 🔧 Khối tiêu đề và breadcrumb, hỗ trợ responsive */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
+          {/* 👉 Nhóm trái: nút Back và tiêu đề */}
+          <div className="flex items-start gap-4 flex-1 min-w-0">
             {currentPath && (
               <Button
                 variant="outline"
@@ -231,15 +234,16 @@ const MovieHome = () => {
                 Back
               </Button>
             )}
-            <div>
+            {/* 🎬 Tiêu đề và breadcrumb */}
+            <div className="min-w-0">
               <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
                 🎬 Movies
               </h1>
-              {/* Breadcrumb */}
-              <nav className="flex mt-2" aria-label="Breadcrumb">
-                <ol className="inline-flex items-center space-x-1 md:space-x-3">
+              {/* 🧭 Breadcrumb có thể xuống dòng khi hẹp */}
+              <nav className="mt-2" aria-label="Breadcrumb">
+                <ol className="flex flex-wrap items-center gap-1 md:gap-3">
                   {breadcrumbItems().map((item, index) => (
-                    <li key={index} className="inline-flex items-center">
+                    <li key={index} className="flex items-center">
                       {index > 0 && (
                         <svg className="w-6 h-6 text-gray-400 mx-1" fill="currentColor" viewBox="0 0 20 20">
                           <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
@@ -263,7 +267,8 @@ const MovieHome = () => {
               </nav>
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          {/* 👉 Nhóm phải: các nút tùy chỉnh có thể xuống dòng */}
+          <div className="flex flex-wrap items-center gap-3">
               {/* Per-page selector */}
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-600 dark:text-gray-300">Per page</span>
@@ -367,11 +372,14 @@ const MovieHome = () => {
         ) : (
           <>
             {/* Current page items (after filtering & sorting) */}
-            <div className={`grid ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5' 
-                : 'grid-cols-1'
-            } gap-6 mb-8`}>
+            {/* 🔒 w-full + overflow-hidden để lưới phim không vượt quá màn hình */}
+            <div
+              className={`grid w-full overflow-hidden ${
+                viewMode === 'grid'
+                  ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
+                  : 'grid-cols-1'
+              } gap-6 mb-8`}
+            >
               {currentMovies.map((movie) => (
                 <MovieCard
                   key={movie.path}

--- a/react-app/src/pages/music/MusicHome.jsx
+++ b/react-app/src/pages/music/MusicHome.jsx
@@ -231,7 +231,8 @@ const MusicHome = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    // 🛡️ overflow-x-hidden để tránh các section kéo rộng body trên mobile
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 overflow-x-hidden">
       {/* Random slider: always show (kept when navigating folders) */}
       <div className="mb-8">
         <MusicRandomSection />
@@ -240,8 +241,10 @@ const MusicHome = () => {
       <div className="p-6">
         {/* Header with breadcrumb and controls */}
         <div className="mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center space-x-4">
+          {/* 🔧 Khối tiêu đề và breadcrumb, hỗ trợ responsive */}
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+            {/* 👉 Nhóm trái: nút Back và breadcrumb */}
+            <div className="flex items-start gap-4 flex-1 min-w-0">
               {/* Back button */}
               <Button
                 variant="outline"
@@ -263,7 +266,8 @@ const MusicHome = () => {
               />
             </div>
 
-            <div className="flex items-center space-x-3">
+            {/* 👉 Nhóm phải: các nút tùy chỉnh có thể xuống dòng */}
+            <div className="flex flex-wrap items-center gap-3">
               {/* Per-page selector */}
               <div className="flex items-center gap-2 mr-2">
                 <span className="text-sm text-gray-600 dark:text-gray-300">Per page</span>
@@ -452,11 +456,14 @@ const MusicHome = () => {
           </div>
         ) : (
           <>
-            <div className={`grid gap-4 ${
-              viewMode === 'grid' 
-                ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6' 
-                : 'grid-cols-1'
-            }`}>
+            {/* 🔒 w-full + overflow-hidden tránh lưới tràn ngang */}
+            <div
+              className={`grid gap-4 w-full overflow-hidden ${
+                viewMode === 'grid'
+                  ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6'
+                  : 'grid-cols-1'
+              }`}
+            >
               {currentMusic.map((music, index) => (
                 <MusicCard
                   key={music.path || index}

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -11,11 +11,12 @@
   width: 100%;
 }
 
+/* 📦 Container flex có khoảng cách giữa các slide và padding hai bên */
 .embla__container {
   display: flex;
   align-items: flex-start;
-  gap: var(--slide-spacing, 0.75rem);
-  padding: 0 var(--slide-spacing, 0.75rem);
+  gap: var(--slide-spacing, 0.5rem);
+  padding: 0 var(--slide-spacing, 0.5rem);
 }
 
 .embla__slide {
@@ -27,36 +28,41 @@
 /* Responsive slide widths */
 @media (max-width: 640px) {
   .embla__slide {
-    flex: 0 0 50%;
-    max-width: 50%;
+    /* 📱 Hai slide mỗi hàng, trừ 3 khoảng cách (2 padding + 1 gap) */
+    flex: 0 0 calc((100% - 3 * var(--slide-spacing, 0.5rem)) / 2);
+    max-width: calc((100% - 3 * var(--slide-spacing, 0.5rem)) / 2);
   }
 }
 
 @media (min-width: 641px) and (max-width: 768px) {
   .embla__slide {
-    flex: 0 0 33.333333%;
-    max-width: 33.333333%;
+    /* 📱 Ba slide mỗi hàng, trừ 4 khoảng cách (2 padding + 2 gap) */
+    flex: 0 0 calc((100% - 4 * var(--slide-spacing, 0.5rem)) / 3);
+    max-width: calc((100% - 4 * var(--slide-spacing, 0.5rem)) / 3);
   }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
   .embla__slide {
-    flex: 0 0 25%;
-    max-width: 25%;
+    /* 💻 Bốn slide mỗi hàng, trừ 5 khoảng cách */
+    flex: 0 0 calc((100% - 5 * var(--slide-spacing, 0.5rem)) / 4);
+    max-width: calc((100% - 5 * var(--slide-spacing, 0.5rem)) / 4);
   }
 }
 
 @media (min-width: 1025px) and (max-width: 1280px) {
   .embla__slide {
-    flex: 0 0 20%;
-    max-width: 20%;
+    /* 🖥️ Năm slide mỗi hàng, trừ 6 khoảng cách */
+    flex: 0 0 calc((100% - 6 * var(--slide-spacing, 0.5rem)) / 5);
+    max-width: calc((100% - 6 * var(--slide-spacing, 0.5rem)) / 5);
   }
 }
 
 @media (min-width: 1281px) {
   .embla__slide {
-    flex: 0 0 16.666667%;
-    max-width: 16.666667%;
+    /* 🖥️🖥️ Sáu slide mỗi hàng, trừ 7 khoảng cách */
+    flex: 0 0 calc((100% - 7 * var(--slide-spacing, 0.5rem)) / 6);
+    max-width: calc((100% - 7 * var(--slide-spacing, 0.5rem)) / 6);
   }
 }
 


### PR DESCRIPTION
## Summary
- cap slider card width and adjust content padding via new `slider` variant
- use slider variant in random/top-view/recent sliders and add mobile padding for music random sections
- shrink embla slide spacing and enlarge music titles for better mobile balance
- prevent sliders and grids from overflowing by constraining wrappers and pages
- add mobile padding to manga, movie and music random sections and hide layout overflow
- hide global horizontal overflow on `html` and `body` to keep slider widths from expanding page
- allow Breadcrumb navigation to wrap lines and stack page headers vertically on small screens

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9403f02588328975d5744c11960c8