### PR TITLE
feat: expand slider cards for full slide

### DIFF
--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -81,6 +81,12 @@ const RandomSlider = ({
   // Local refresh trigger for forcing re-renders
   const [localRefreshTrigger, setLocalRefreshTrigger] = useState(0);
 
+  // Skeleton aspect ratio based on type
+  const skeletonAspect =
+    type === 'music' ? 'aspect-square' :
+    type === 'movie' ? 'aspect-video' :
+    'aspect-[3/4]';
+
   // Navigation functions
   const scrollPrev = useCallback(() => {
     if (emblaApi) emblaApi.scrollPrev();
@@ -302,7 +308,9 @@ const RandomSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  <div
+                    className={`bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full ${skeletonAspect}`}
+                  />
                 </div>
               ))
             ) : (
@@ -318,7 +326,7 @@ const RandomSlider = ({
                       await handleToggleFavorite(toggleItem);
                     }}
                     variant="compact"
-                    className="w-48"
+                    className="w-full"
                   />
                 </div>
               ))

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -62,6 +62,12 @@ const RecentSlider = ({
   
   // Local refresh trigger for forcing re-renders
   const [localRefreshTrigger, setLocalRefreshTrigger] = useState(0);
+
+  // Skeleton aspect ratio based on type
+  const skeletonAspect =
+    type === 'music' ? 'aspect-square' :
+    type === 'movie' ? 'aspect-video' :
+    'aspect-[3/4]';
   
   // Don't render if recent tracking is disabled (only check for manga type)
   if (type === 'manga' && (!mangaSettings || !mangaSettings.enableRecentTracking)) {
@@ -371,7 +377,9 @@ const RecentSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  <div
+                    className={`bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full ${skeletonAspect}`}
+                  />
                 </div>
               ))
             ) : (
@@ -397,7 +405,7 @@ const RecentSlider = ({
                       onToggleFavorite={async (toggleItem) => {
                         await handleToggleFavorite(toggleItem);
                       }}
-                      className="w-48"
+                      className="w-full"
                     />
                   </div>
                 </div>

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -56,6 +56,12 @@ const TopViewSlider = ({
   // Local refresh trigger for forcing re-renders
   const [localRefreshTrigger, setLocalRefreshTrigger] = useState(0);
 
+  // Skeleton aspect ratio based on type
+  const skeletonAspect =
+    type === 'music' ? 'aspect-square' :
+    type === 'movie' ? 'aspect-video' :
+    'aspect-[3/4]';
+
   // Top view items hook
   const { data: items, isLoading: loading, error } = useTopViewItems(type, {
     enabled: isVisible,
@@ -251,7 +257,9 @@ const TopViewSlider = ({
               // Loading skeleton
               Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="embla__slide">
-                  <div className="bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-48 h-64" />
+                  <div
+                    className={`bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse w-full ${skeletonAspect}`}
+                  />
                 </div>
               ))
             ) : (
@@ -280,7 +288,7 @@ const TopViewSlider = ({
                       showViews={true}
                       onToggleFavorite={() => handleToggleFavorite(item)}
                       variant="compact"
-                      className="w-48"
+                      className="w-full"
                       overlayMode={type === 'manga' ? 'views' : 'type'}
                     />
                   </div>

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -18,6 +18,13 @@
   padding: 0 var(--slide-spacing, 0.75rem);
 }
 
+/* Match header padding on small screens */
+@media (max-width: 640px) {
+  .embla__container {
+    padding: 0 1.5rem;
+  }
+}
+
 .embla__slide {
   flex: 0 0 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- ensure Random, Recent, and TopView sliders use full-width cards and skeletons
- align slider padding with header on small screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm --workspace react-app run lint` (fails: ESLint configuration missing)


------
https://chatgpt.com/codex/tasks/task_e_68a9936bfa8883288207c90a9af59dc5