### PR TITLE
feat: enable swipe seek in movie player

### DIFF
--- a/react-app/src/pages/movie/MoviePlayer.jsx
+++ b/react-app/src/pages/movie/MoviePlayer.jsx
@@ -423,11 +423,12 @@ const MoviePlayer = () => {
   // Video gesture controls
   const handlePointerDown = (e) => {
     if (!videoRef.current) return;
-    
+
+    e.preventDefault();
     setDragStartX(e.clientX);
     setStartTime(videoRef.current.currentTime);
     setDragging(false);
-    
+
     if (gestureTargetRef.current) {
       gestureTargetRef.current.setPointerCapture(e.pointerId);
     }
@@ -450,17 +451,20 @@ const MoviePlayer = () => {
 
   const handlePointerUp = (e) => {
     if (dragStartX === null || !videoRef.current) return;
-    
+
     const diff = e.clientX - dragStartX;
     if (dragging) {
       e.preventDefault();
       const skipped = Math.floor(diff / PIXELS_PER_SECOND);
       // Removed toast for skip gesture
+    } else {
+      // Forward tap to the video element for native controls
+      videoRef.current.click();
     }
-    
+
     setDragStartX(null);
     setDragging(false);
-    
+
     if (gestureTargetRef.current) {
       gestureTargetRef.current.releasePointerCapture(e.pointerId);
     }
@@ -609,13 +613,13 @@ const MoviePlayer = () => {
               onDoubleClick={handleDoubleClick}
             />
             {/* Gesture overlay */}
-            <div 
+            <div
               ref={gestureTargetRef}
               className="absolute inset-0"
-              style={{ 
-                pointerEvents: dragging ? 'auto' : 'none',
+              style={{
                 background: 'transparent',
-                cursor: dragging ? 'grabbing' : 'default'
+                cursor: dragging ? 'grabbing' : 'grab',
+                touchAction: 'none'
               }}
               onPointerDown={handlePointerDown}
               onPointerMove={handlePointerMove}


### PR DESCRIPTION
## Summary
- enable horizontal swipe gestures on movie player video
- forward taps to native controls for smoother playback

## Testing
- `npm --workspace react-app run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f93d27c83289e65d4b797bd77d4