### PR TITLE
Fix slider overflow and responsive card sizing

### DIFF
--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -232,7 +232,7 @@ const RandomSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -275,7 +275,7 @@ const RecentSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -194,7 +194,7 @@ const TopViewSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -44,6 +44,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {
@@ -54,6 +55,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease-in-out;
+  overflow-x: hidden;
 }
 
 /* Dark mode */

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -42,34 +42,11 @@
   }
 }
 
-@media (min-width: 641px) and (max-width: 768px) {
+/* All larger screens show 3 cards per view */
+@media (min-width: 641px) {
   .embla__slide {
     flex: 0 0 33.333333%;
     max-width: 33.333333%;
-    box-sizing: border-box;
-  }
-}
-
-@media (min-width: 769px) and (max-width: 1024px) {
-  .embla__slide {
-    flex: 0 0 25%;
-    max-width: 25%;
-    box-sizing: border-box;
-  }
-}
-
-@media (min-width: 1025px) and (max-width: 1280px) {
-  .embla__slide {
-    flex: 0 0 20%;
-    max-width: 20%;
-    box-sizing: border-box;
-  }
-}
-
-@media (min-width: 1281px) {
-  .embla__slide {
-    flex: 0 0 16.666667%;
-    max-width: 16.666667%;
     box-sizing: border-box;
   }
 }


### PR DESCRIPTION
## Summary
- Prevent slider sections from bleeding beyond the viewport
- Clamp Embla slides to two or three cards per row across breakpoints
- Hide horizontal overflow globally to keep header aligned

## Testing
- `npm --workspace react-app run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9bfd67c483288a1e34e3960db4f0