### PR TITLE
Fix slider overflow and responsive card layout

### DIFF
--- a/react-app/src/components/common/RandomSlider.jsx
+++ b/react-app/src/components/common/RandomSlider.jsx
@@ -232,7 +232,7 @@ const RandomSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/RecentSlider.jsx
+++ b/react-app/src/components/common/RecentSlider.jsx
@@ -275,7 +275,7 @@ const RecentSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/components/common/TopViewSlider.jsx
+++ b/react-app/src/components/common/TopViewSlider.jsx
@@ -194,7 +194,7 @@ const TopViewSlider = ({
   }
 
   return (
-    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 ${className}`}>
+    <div ref={containerRef} className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm mb-6 overflow-hidden ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4">
         <div className="flex items-center space-x-3">

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -54,6 +54,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease-in-out;
+  overflow-x: hidden; /* Bleed-guard for sliders and grids */
 }
 
 /* Dark mode */

--- a/react-app/src/styles/components/embla.css
+++ b/react-app/src/styles/components/embla.css
@@ -13,6 +13,7 @@
 .embla__viewport {
   overflow: hidden;
   width: 100%;
+  scroll-snap-type: x mandatory;
 }
 
 .embla__container {
@@ -27,6 +28,7 @@
   flex: 0 0 auto;
   min-width: 0;
   position: relative;
+  scroll-snap-align: start;
 }
 
 /* Responsive slide widths */

--- a/react-app/src/styles/components/manga-card.css
+++ b/react-app/src/styles/components/manga-card.css
@@ -159,26 +159,14 @@
 
 /* Slider variant */
 .manga-card.slider {
-  width: 160px;
+  width: 100%;
   flex-shrink: 0;
-}
-
-@media (min-width: 768px) {
-  .manga-card.slider {
-    width: 180px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .manga-card.slider {
-    width: 200px;
-  }
 }
 
 /* Grid variant */
 .manga-card.grid {
   width: 100%;
-  max-width: 240px;
+  max-width: 100%;
 }
 
 /* Loading state */
@@ -201,15 +189,11 @@
 }
 
 /* Mobile responsive */
-@media (max-width: 640px) {
-  .manga-card.slider {
-    width: 140px;
-  }
-  
-  .manga-card-title {
-    padding: 0.5rem;
-    font-size: 0.75rem;
-  }
+  @media (max-width: 640px) {
+    .manga-card-title {
+      padding: 0.5rem;
+      font-size: 0.75rem;
+    }
   
   .view-count-badge {
     font-size: 0.625rem;


### PR DESCRIPTION
## Summary
- Prevent slider bleed by hiding overflow on slider containers
- Add scroll snap rules and global overflow guard for smooth slider edges
- Make slider/grid cards fully responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa9bfd67c483288a1e34e3960db4f0