### PR TITLE
Refine offline mode experience and caching

### DIFF
--- a/react-app/public/offline.html
+++ b/react-app/public/offline.html
@@ -5,11 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Offline - MainWebSite</title>
     <style>
+        :root {
+            color-scheme: dark light;
+        }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             margin: 0;
             padding: 20px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #1f2937 0%, #0f172a 100%);
             color: white;
             min-height: 100vh;
             display: flex;
@@ -17,61 +20,147 @@
             justify-content: center;
         }
         .container {
+            width: 100%;
+            max-width: 960px;
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+        .header {
             text-align: center;
-            max-width: 400px;
         }
         h1 {
-            font-size: 2.5rem;
-            margin-bottom: 1rem;
+            font-size: clamp(2.2rem, 4vw, 3rem);
+            margin-bottom: 12px;
         }
-        p {
-            font-size: 1.1rem;
-            margin-bottom: 2rem;
-            opacity: 0.9;
+        p.description {
+            font-size: 1.05rem;
+            margin: 0 auto;
+            max-width: 560px;
+            color: rgba(255, 255, 255, 0.8);
         }
-        .buttons {
+        .modes {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 20px;
+        }
+        .mode-card {
+            background: rgba(15, 23, 42, 0.8);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            border-radius: 18px;
+            padding: 28px 24px;
+            text-align: center;
+            backdrop-filter: blur(12px);
+            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
             display: flex;
-            gap: 1rem;
-            justify-content: center;
-            flex-wrap: wrap;
+            flex-direction: column;
+            gap: 16px;
+            transition: transform 0.3s ease, border-color 0.3s ease;
+        }
+        .mode-card.ready:hover {
+            transform: translateY(-6px);
+            border-color: rgba(74, 222, 128, 0.6);
+        }
+        .mode-icon {
+            font-size: 48px;
+        }
+        .mode-title {
+            font-size: 1.6rem;
+            font-weight: 700;
+        }
+        .mode-description {
+            font-size: 0.95rem;
+            color: rgba(255, 255, 255, 0.75);
+            min-height: 60px;
         }
         button {
-            background: rgba(255,255,255,0.2);
-            border: 2px solid rgba(255,255,255,0.3);
-            color: white;
-            padding: 12px 24px;
-            border-radius: 8px;
-            cursor: pointer;
+            border: none;
+            border-radius: 9999px;
+            padding: 12px 20px;
             font-size: 1rem;
-            transition: all 0.3s ease;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, opacity 0.2s ease;
         }
-        button:hover {
-            background: rgba(255,255,255,0.3);
+        button.primary {
+            background: linear-gradient(135deg, #22c55e, #16a34a);
+            color: white;
+            box-shadow: 0 10px 20px rgba(34, 197, 94, 0.35);
+        }
+        button.primary:hover {
             transform: translateY(-2px);
         }
-        .icon {
-            font-size: 4rem;
-            margin-bottom: 1rem;
+        button.secondary {
+            background: rgba(148, 163, 184, 0.2);
+            color: rgba(226, 232, 240, 0.75);
+            cursor: not-allowed;
+        }
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 12px;
+            color: rgba(255, 255, 255, 0.7);
+        }
+        .actions button {
+            background: rgba(148, 163, 184, 0.15);
+            color: white;
+            border-radius: 12px;
+        }
+        .actions button:hover {
+            transform: none;
+            opacity: 0.85;
         }
     </style>
 </head>
 <body>
     <div class="container">
-        <div class="icon">📱</div>
-        <h1>App đang offline</h1>
-        <p>Không thể kết nối với server. App đang chạy ở chế độ offline với các tính năng giới hạn.</p>
-        <div class="buttons">
-            <button onclick="window.location.reload()">🔄 Thử lại</button>
-            <button onclick="goToMain()">🏠 Trang chủ</button>
+        <header class="header">
+            <div style="font-size: 64px; margin-bottom: 16px;">📴</div>
+            <h1>Không có kết nối mạng</h1>
+            <p class="description">
+                MainWebSite đang chạy ở chế độ offline. Bạn vẫn có thể truy cập nội dung đã lưu trước đó.
+            </p>
+        </header>
+
+        <section class="modes">
+            <article class="mode-card ready">
+                <div class="mode-icon">📚</div>
+                <div class="mode-title">Manga</div>
+                <p class="mode-description">
+                    Truy cập các chapter đã download và tiếp tục đọc ngay cả khi mất mạng.
+                </p>
+                <button class="primary" onclick="openMode('/offline/manga')">Mở thư viện</button>
+            </article>
+            <article class="mode-card">
+                <div class="mode-icon">🎬</div>
+                <div class="mode-title">Movie</div>
+                <p class="mode-description">
+                    Chế độ xem phim offline sẽ có mặt trong những bản cập nhật sắp tới.
+                </p>
+                <button class="secondary" disabled>Đang phát triển</button>
+            </article>
+            <article class="mode-card">
+                <div class="mode-icon">🎵</div>
+                <div class="mode-title">Music</div>
+                <p class="mode-description">
+                    Đang chuẩn bị hỗ trợ nghe nhạc offline. Hãy đợi thêm một chút nhé!
+                </p>
+                <button class="secondary" disabled>Đang phát triển</button>
+            </article>
+        </section>
+
+        <div class="actions">
+            <button onclick="window.location.reload()">🔄 Thử kết nối lại</button>
+            <button onclick="openMode('/')">🏠 Quay về trang chủ</button>
         </div>
     </div>
 
     <script>
-        function goToMain() {
-            window.location.href = '/';
+        function openMode(path) {
+            window.location.href = path;
         }
-        
-        // Auto retry after 30 seconds
+
         setTimeout(() => {
             console.log('Auto retrying connection...');
             window.location.reload();

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -21,7 +21,10 @@ import MusicPlayerV2 from '@/pages/music/MusicPlayerV2';
 import MusicPlaylists from '@/pages/music/MusicPlaylists';
 import Settings from '@/pages/Settings';
 import NotFound from '@/pages/NotFound';
-import OfflineLibrary from '@/pages/OfflineLibrary';
+import OfflineHome from '@/pages/offline/OfflineHome';
+import OfflineMangaLibrary from '@/pages/offline/OfflineMangaLibrary';
+import OfflineMovieLibrary from '@/pages/offline/OfflineMovieLibrary';
+import OfflineMusicLibrary from '@/pages/offline/OfflineMusicLibrary';
 
 function MusicPlayerRouter() {
   const { playerSettings } = useMusicStore();
@@ -85,7 +88,12 @@ function App() {
         
         {/* Settings */}
         <Route path="settings" element={<Settings />} />
-        <Route path="offline" element={<OfflineLibrary />} />
+        <Route path="offline">
+          <Route index element={<OfflineHome />} />
+          <Route path="manga" element={<OfflineMangaLibrary />} />
+          <Route path="movie" element={<OfflineMovieLibrary />} />
+          <Route path="music" element={<OfflineMusicLibrary />} />
+        </Route>
         
         {/* 404 */}
         <Route path="*" element={<NotFound />} />

--- a/react-app/src/components/common/Layout.jsx
+++ b/react-app/src/components/common/Layout.jsx
@@ -1,8 +1,8 @@
 // 📁 src/components/common/Layout.jsx
 // 🏗️ Main layout component
 
-import React from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import { motion, AnimatePresence } from 'framer-motion';
 import Header from './Header';
@@ -14,9 +14,36 @@ import PlaylistModal from '@/components/music/PlaylistModal';
 const Layout = () => {
   const { sidebarOpen, loading, setSidebarOpen } = useUIStore();
   const location = useLocation();
+  const navigate = useNavigate();
   const isMoviePlayer = location.pathname.startsWith('/movie/player');
   const isHomePage = location.pathname === '/';
   const isSelectPage = location.pathname === '/manga/select';
+
+  useEffect(() => {
+    const offlineAllowedPrefixes = ['/offline', '/manga/reader'];
+
+    const redirectToOffline = () => {
+      if (typeof window === 'undefined' || navigator.onLine) {
+        return;
+      }
+
+      const currentPath = window.location.pathname;
+      const isAllowed = offlineAllowedPrefixes.some((prefix) => currentPath.startsWith(prefix));
+
+      if (!isAllowed) {
+        navigate('/offline', { replace: true });
+      }
+    };
+
+    // Run immediately if the app loads offline
+    redirectToOffline();
+
+    window.addEventListener('offline', redirectToOffline);
+
+    return () => {
+      window.removeEventListener('offline', redirectToOffline);
+    };
+  }, [navigate, location.pathname]);
   
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-dark-900 transition-colors duration-200">

--- a/react-app/src/hooks/useServiceWorker.js
+++ b/react-app/src/hooks/useServiceWorker.js
@@ -194,8 +194,8 @@ export function useServiceWorker() {
 
   // Helper to format cache names for display
   const formatCacheName = (name) => {
-    if (name.includes('static')) return '📦 App Shell';
-    if (name.includes('dynamic')) return '🌐 API Cache';
+    if (name.includes('offline-core')) return '📴 Offline Essentials';
+    if (name.includes('reader-dynamic') || name.includes('dynamic')) return '🌐 API Cache';
     if (name.includes('chapter-images')) return '🖼️ Offline Images';
     return `💾 ${name}`;
   };

--- a/react-app/src/pages/Home.jsx
+++ b/react-app/src/pages/Home.jsx
@@ -271,14 +271,14 @@ const Home = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.6 }}
           >
-            <Button 
+            <Button
               onClick={() => navigate('/offline')}
               className="bg-green-600 hover:bg-green-700 text-white px-6 py-3 text-lg font-medium"
             >
-              📚 Mở Offline Library
+              🔌 Mở chế độ Offline
             </Button>
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-              Truy cập các chapter đã tải để đọc offline
+              Chọn Manga, Movie hoặc Music đã lưu để sử dụng offline
             </p>
           </motion.div>
         </div>

--- a/react-app/src/pages/offline/OfflineHome.jsx
+++ b/react-app/src/pages/offline/OfflineHome.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/common/Button';
+
+const MODES = [
+  {
+    id: 'manga',
+    title: 'Manga',
+    description: 'Đọc các chapter đã tải xuống và tiếp tục tiến độ đọc.',
+    icon: '📚',
+    path: '/offline/manga',
+    ready: true,
+  },
+  {
+    id: 'movie',
+    title: 'Movie',
+    description: 'Danh sách phim offline sẽ xuất hiện tại đây (sắp ra mắt).',
+    icon: '🎬',
+    path: '/offline/movie',
+    ready: false,
+  },
+  {
+    id: 'music',
+    title: 'Music',
+    description: 'Kho nhạc offline sẽ được bổ sung trong phiên bản tới.',
+    icon: '🎵',
+    path: '/offline/music',
+    ready: false,
+  },
+];
+
+const OfflineHome = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-5xl mx-auto py-10 space-y-10">
+      <div className="text-center space-y-4">
+        <div className="text-5xl">📴</div>
+        <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white">
+          Chế độ Offline
+        </h1>
+        <p className="text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+          Không thể kết nối tới server. Chọn chế độ để sử dụng các nội dung đã được tải về máy.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {MODES.map((mode) => (
+          <div
+            key={mode.id}
+            className="flex flex-col h-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+          >
+            <div className="flex-1 p-6 space-y-4 text-center">
+              <div className="text-4xl">{mode.icon}</div>
+              <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">{mode.title}</h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{mode.description}</p>
+            </div>
+            <div className="p-6 pt-0">
+              <Button
+                className="w-full justify-center"
+                variant={mode.ready ? 'primary' : 'outline'}
+                onClick={() => navigate(mode.path)}
+                disabled={!mode.ready}
+              >
+                {mode.ready ? 'Mở thư viện' : 'Đang phát triển'}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="text-center text-sm text-gray-500 dark:text-gray-400">
+        Một số tính năng chỉ hoạt động khi bạn đã tải nội dung trước đó. Trở lại trực tuyến để đồng bộ thêm dữ liệu mới.
+      </div>
+    </div>
+  );
+};
+
+export default OfflineHome;

--- a/react-app/src/pages/offline/OfflineMangaLibrary.jsx
+++ b/react-app/src/pages/offline/OfflineMangaLibrary.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, Trash2, Calendar, Eye, Grid, List } from 'lucide-react';
-import { DEFAULT_IMAGES } from '../constants';
-import Button from '../components/common/Button';
-import { getChapters, deleteChapterCompletely, clearAllOfflineData, getStorageAnalysis } from '../utils/offlineLibrary';
-import { formatDate, formatSize } from '../utils/formatters';
+import { DEFAULT_IMAGES } from '../../constants';
+import Button from '../../components/common/Button';
+import { getChapters, deleteChapterCompletely, clearAllOfflineData, getStorageAnalysis } from '../../utils/offlineLibrary';
+import { formatDate, formatSize } from '../../utils/formatters';
 import toast from 'react-hot-toast';
 
-export default function OfflineLibrary() {
+export default function OfflineMangaLibrary() {
   const [chapters, setChapters] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState('newest'); // 'newest', 'oldest', 'name'
@@ -171,16 +171,23 @@ export default function OfflineLibrary() {
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
-              Offline Library
+              Manga Offline Library
             </h1>
             <p className="text-gray-600 dark:text-gray-400">
               {chapters.length} chapter{chapters.length !== 1 ? 's' : ''} đã tải offline
             </p>
           </div>
-          
+
           {/* Actions */}
-          {chapters.length > 0 && (
-            <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2 justify-end">
+            <Button
+              variant="outline"
+              onClick={() => navigate('/offline')}
+              className="border-gray-200 hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-700"
+            >
+              ⬅️ Quay lại chế độ Offline
+            </Button>
+            {chapters.length > 0 && (
               <Button
                 variant="outline"
                 onClick={() => setShowClearModal(true)}
@@ -189,8 +196,8 @@ export default function OfflineLibrary() {
                 <Trash2 size={16} />
                 <span className="ml-1">Xóa tất cả</span>
               </Button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
         
         {/* Storage Statistics */}

--- a/react-app/src/pages/offline/OfflineMovieLibrary.jsx
+++ b/react-app/src/pages/offline/OfflineMovieLibrary.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/common/Button';
+
+const OfflineMovieLibrary = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 space-y-6 text-center">
+      <div className="text-5xl">🎬</div>
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Movie Offline</h1>
+      <p className="text-base text-gray-600 dark:text-gray-400">
+        Chúng tôi đang chuẩn bị hỗ trợ lưu trữ phim để xem offline. Tính năng này sẽ xuất hiện trong phiên bản tiếp theo.
+      </p>
+      <div className="space-y-2">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Trong lúc chờ đợi, bạn có thể quay lại trung tâm offline để chọn nội dung khác.
+        </p>
+        <Button className="justify-center" onClick={() => navigate('/offline')}>
+          ⬅️ Quay lại chế độ Offline
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OfflineMovieLibrary;

--- a/react-app/src/pages/offline/OfflineMusicLibrary.jsx
+++ b/react-app/src/pages/offline/OfflineMusicLibrary.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/common/Button';
+
+const OfflineMusicLibrary = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 space-y-6 text-center">
+      <div className="text-5xl">🎵</div>
+      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Music Offline</h1>
+      <p className="text-base text-gray-600 dark:text-gray-400">
+        Tính năng lưu nhạc offline đang được phát triển. Bạn sẽ sớm có thể nghe playlist yêu thích mà không cần internet.
+      </p>
+      <div className="space-y-2">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Hãy quay lại trung tâm offline để chọn nội dung hiện có.
+        </p>
+        <Button className="justify-center" onClick={() => navigate('/offline')}>
+          ⬅️ Quay lại chế độ Offline
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OfflineMusicLibrary;

--- a/react-app/src/utils/serviceWorkerManager.js
+++ b/react-app/src/utils/serviceWorkerManager.js
@@ -163,12 +163,21 @@ class ServiceWorkerManager {
 
     try {
       const cacheInfo = await this.getCacheInfo();
-      const hasAppShell = cacheInfo?.caches?.['manga-static-v2.0.0']?.count > 0;
-      
+      const caches = cacheInfo?.caches || {};
+      const offlineEntry = Object.values(caches).find((entry) => entry?.type === 'offline-core');
+      const hasOfflineFallback = Array.isArray(offlineEntry?.urls)
+        ? offlineEntry.urls.some((url) => url === '/offline.html')
+        : false;
+      const hasChapterImages = (caches['chapter-images']?.count || 0) > 0;
+
       return {
-        capable: hasAppShell,
-        reason: hasAppShell ? 'App shell cached' : 'App shell not cached',
-        cacheInfo
+        capable: hasOfflineFallback,
+        reason: hasOfflineFallback ? 'Offline fallback cached' : 'Offline fallback missing',
+        cacheInfo,
+        offlineStatus: {
+          hasOfflineFallback,
+          hasChapterImages
+        }
       };
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary
- overhaul the service worker to only precache the offline shell and reader assets while cleaning legacy caches and serving the dedicated offline fallback
- redesign the static offline.html to present the new offline mode selector and add routed offline pages for manga, movie, and music (with placeholders where appropriate)
- automatically redirect users to the offline hub when the app detects an offline state, update the home CTA, and relocate the manga offline library with back navigation support
- adjust the service worker manager to report the new cache structure so offline capability checks remain accurate

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9eee32ec833283a2ec8d7c472568