### PR TITLE
feat: add thumbnail extraction control to sidebar

### DIFF
--- a/backend/api/music/extract-thumbnail.js
+++ b/backend/api/music/extract-thumbnail.js
@@ -65,8 +65,7 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
         }
       }
       if (result && result.success) {
-        const increment =
-          typeof result.count === "number" ? result.count : 1;
+        const increment = typeof result.count === "number" ? result.count : 1;
         count += increment;
       }
     }
@@ -85,12 +84,7 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
       const db = getMusicDB(key);
       db.prepare(
         `UPDATE folders SET thumbnail = ?, updatedAt = ? WHERE name = ? AND path = ?`
-      ).run(
-        folderThumbRelative,
-        Date.now(),
-        folderName,
-        relPath
-      );
+      ).run(folderThumbRelative, Date.now(), folderName, relPath);
     }
 
     return {
@@ -126,7 +120,7 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
         const name = path.basename(relPath, path.extname(relPath));
         const baseDir = path.dirname(absPath);
         const thumbFolder = path.join(baseDir, ".thumbnail");
-        if (!fs.existsSync(thumbFolder)) fs.mkdirSync(thumbFolder);
+        fs.mkdirSync(thumbFolder, { recursive: true }); // ✅ an toàn khi chạy song song
         const thumbFile = path.join(thumbFolder, name + ext);
         const shouldWrite = overwrite || !fs.existsSync(thumbFile);
         if (shouldWrite) {

--- a/backend/api/music/extract-thumbnail.js
+++ b/backend/api/music/extract-thumbnail.js
@@ -32,16 +32,35 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
         result &&
         result.success &&
         result.thumb &&
-        entry.isFile() &&
-        [
-          ".mp3", ".flac", ".wav", ".aac", ".m4a", ".ogg", ".opus", ".wma", ".alac", ".aiff"
-        ].includes(path.extname(entry.name).toLowerCase())
+        (entry.isFile() || entry.isDirectory())
       ) {
-        const thumbDir = path.join(absPath, ".thumbnail");
-        const name = path.basename(entry.name, path.extname(entry.name));
-        const ext = path.extname(result.thumb); // lấy .jpg hoặc .png
-        const thumbFile = path.join(thumbDir, name + ext);
-        if (fs.existsSync(thumbFile)) {
+        let thumbFile = null;
+        if (
+          entry.isFile() &&
+          [
+            ".mp3",
+            ".flac",
+            ".wav",
+            ".aac",
+            ".m4a",
+            ".ogg",
+            ".opus",
+            ".wma",
+            ".alac",
+            ".aiff",
+          ].includes(path.extname(entry.name).toLowerCase())
+        ) {
+          const thumbDir = path.join(absPath, ".thumbnail");
+          const name = path.basename(entry.name, path.extname(entry.name));
+          const ext = path.extname(result.thumb); // lấy .jpg hoặc .png
+          thumbFile = path.join(thumbDir, name + ext);
+        } else if (entry.isDirectory()) {
+          if (result.thumb) {
+            const childAbsPath = path.join(absPath, entry.name);
+            thumbFile = path.join(childAbsPath, result.thumb);
+          }
+        }
+        if (thumbFile && fs.existsSync(thumbFile)) {
           firstMusicThumb = thumbFile;
         }
       }
@@ -53,6 +72,7 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
     }
 
     // Tạo thumbnail đại diện cho folder nếu có nhạc
+    let folderThumbRelative = null;
     if (firstMusicThumb) {
       const folderName = path.basename(absPath);
       const thumbDir = path.join(absPath, ".thumbnail");
@@ -60,19 +80,25 @@ async function extractThumbnailSmart({ key, relPath = "", overwrite = false }) {
       if (overwrite || !fs.existsSync(folderThumb)) {
         fs.copyFileSync(firstMusicThumb, folderThumb);
       }
+      folderThumbRelative = path.posix.join(".thumbnail", folderName + ".jpg");
       // Update thumbnail cho folder trong DB
       const db = getMusicDB(key);
       db.prepare(
         `UPDATE folders SET thumbnail = ?, updatedAt = ? WHERE name = ? AND path = ?`
       ).run(
-        path.posix.join(".thumbnail", folderName + ".jpg"),
+        folderThumbRelative,
         Date.now(),
         folderName,
         relPath
       );
     }
 
-    return { success: true, message: "Extracted all in folder", count };
+    return {
+      success: true,
+      message: "Extracted all in folder",
+      count,
+      thumb: folderThumbRelative,
+    };
   }
 
   // Nếu là file nhạc: extract thumbnail

--- a/react-app/src/components/common/DatabaseActions.jsx
+++ b/react-app/src/components/common/DatabaseActions.jsx
@@ -16,6 +16,41 @@ import {
 } from '@/utils/databaseOperations';
 import Button from './Button';
 
+const ThumbnailOverwriteToggle = ({
+  defaultChecked = false,
+  onChange,
+}) => {
+  const [checked, setChecked] = React.useState(defaultChecked);
+
+  React.useEffect(() => {
+    setChecked(defaultChecked);
+  }, [defaultChecked]);
+
+  React.useEffect(() => {
+    onChange?.(checked);
+  }, [checked, onChange]);
+
+  return (
+    <label className="flex items-start space-x-3 p-3 border border-purple-200 dark:border-purple-700 rounded-lg bg-purple-50/60 dark:bg-purple-900/20 cursor-pointer">
+      <input
+        type="checkbox"
+        className="mt-1 h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+      />
+      <div className="text-sm text-left">
+        <p className="font-semibold text-purple-800 dark:text-purple-100">
+          Ghi đè thumbnail hiện có
+        </p>
+        <p className="text-xs text-purple-700 dark:text-purple-300">
+          Khi bật tùy chọn này hệ thống sẽ tạo lại toàn bộ thumbnail ngay cả khi đã tồn tại.
+          Nếu tắt, các thumbnail sẵn có sẽ được giữ nguyên và bỏ qua.
+        </p>
+      </div>
+    </label>
+  );
+};
+
 const DatabaseActions = ({ 
   contentType = null, // If null, will auto-detect from sourceKey
   sourceKey = null, // If null, will use from auth store
@@ -45,6 +80,7 @@ const DatabaseActions = ({
   // Current folder path for contextual actions
   const moviePath = useMovieStore((state) => state.currentPath);
   const musicPath = useMusicStore((state) => state.currentPath);
+  const overwriteRef = React.useRef(false);
   const currentPath = React.useMemo(() => {
     if (currentContentType === 'movie') return moviePath || '';
     if (currentContentType === 'music') return musicPath || '';
@@ -106,6 +142,7 @@ const DatabaseActions = ({
     }
 
     const folderLabel = currentPath || 'Thư mục gốc (root)';
+    overwriteRef.current = false;
 
     confirmModal({
       title: `🖼️ ${labels.thumbnail || 'Quét thumbnail'}`,
@@ -122,6 +159,12 @@ const DatabaseActions = ({
               </li>
             </ul>
           </div>
+          <ThumbnailOverwriteToggle
+            defaultChecked={false}
+            onChange={(value) => {
+              overwriteRef.current = value;
+            }}
+          />
           <p className="text-xs text-purple-600 dark:text-purple-300">
             Lưu ý: thao tác có thể mất vài phút tùy số lượng file. Vui lòng giữ ứng dụng mở trong khi xử lý.
           </p>
@@ -133,7 +176,7 @@ const DatabaseActions = ({
         performThumbnailExtraction(
           currentContentType,
           currentSourceKey,
-          { path: currentPath },
+          { path: currentPath, overwrite: overwriteRef.current },
           (data) => {
             const countInfo = data.count ? `Đã xử lý ${data.count} mục.` : '';
             const successTitle = labels.thumbnailSuccess || '✅ Hoàn tất!';

--- a/react-app/src/utils/api.js
+++ b/react-app/src/utils/api.js
@@ -166,7 +166,7 @@ export const apiService = {
   getVideoCache: (params, config = {}) => api.get(`${API.ENDPOINTS.MOVIE}/video-cache`, { params, ...config }),
     getFavorites: (params) => api.get(`${API.ENDPOINTS.MOVIE}/favorite-movie`, { params }),
     toggleFavorite: (dbkey, path, value) => api.post(`${API.ENDPOINTS.MOVIE}/favorite-movie`, { dbkey, path, value }),
-    extractThumbnail: (params) => api.post(`${API.ENDPOINTS.MOVIE}/extract-movie-thumbnail`, params),
+    extractThumbnail: (params) => api.post(`${API.ENDPOINTS.MOVIE}/extract-thumbnail`, params),
     setThumbnail: (params) => api.post(`${API.ENDPOINTS.MOVIE}/set-thumbnail`, params),
     resetDb: (params) => api.delete(`${API.ENDPOINTS.MOVIE}/reset-cache-movie`, { params, timeout: 0 }),
     scan: (params) => api.post(`${API.ENDPOINTS.MOVIE}/scan-movie`, params, { timeout: 0 }),

--- a/react-app/src/utils/databaseOperations.js
+++ b/react-app/src/utils/databaseOperations.js
@@ -245,7 +245,7 @@ export const performThumbnailExtraction = async (
   const movieState = useMovieStore.getState();
   const musicState = useMusicStore.getState();
 
-  const { path = null } = options || {};
+  const { path = null, overwrite = false } = options || {};
   const currentPath =
     path ?? (type === 'movie' ? movieState.currentPath : musicState.currentPath) ?? '';
 
@@ -258,11 +258,13 @@ export const performThumbnailExtraction = async (
       response = await apiService.movie.extractThumbnail({
         key: sourceKey,
         path: currentPath || '',
+        overwrite,
       });
     } else {
       response = await apiService.music.extractThumbnail({
         key: sourceKey,
         path: currentPath || '',
+        overwrite,
       });
     }
 

--- a/react-app/src/utils/databaseOperations.js
+++ b/react-app/src/utils/databaseOperations.js
@@ -1,7 +1,7 @@
 // 📁 src/utils/databaseOperations.js
 // 🔄 Centralized database operations with loading states and confirmations
 
-import { useUIStore } from '@/store';
+import { useUIStore, useMovieStore, useMusicStore } from '@/store';
 import { apiService } from './api';
 
 /**
@@ -216,8 +216,90 @@ export const performDatabaseReset = async (type, sourceKey, rootFolder = null, o
 };
 
 /**
+ * Thumbnail extraction operation for movie & music
+ * @param {string} type - Content type ('movie', 'music')
+ * @param {string} sourceKey - Database key
+ * @param {Object} options - Additional options
+ * @param {string|null} options.path - Optional explicit folder path to extract
+ * @param {Function} onSuccess - Success callback
+ * @param {Function} onError - Error callback
+ */
+export const performThumbnailExtraction = async (
+  type,
+  sourceKey,
+  options = {},
+  onSuccess,
+  onError
+) => {
+  if (!['movie', 'music'].includes(type)) {
+    onError?.('Thumbnail extraction is only supported for movie or music sources');
+    return;
+  }
+
+  if (!sourceKey) {
+    onError?.('Missing source key');
+    return;
+  }
+
+  const { setLoading } = useUIStore.getState();
+  const movieState = useMovieStore.getState();
+  const musicState = useMusicStore.getState();
+
+  const { path = null } = options || {};
+  const currentPath =
+    path ?? (type === 'movie' ? movieState.currentPath : musicState.currentPath) ?? '';
+
+  try {
+    setLoading(true);
+
+    let response;
+
+    if (type === 'movie') {
+      response = await apiService.movie.extractThumbnail({
+        key: sourceKey,
+        path: currentPath || '',
+      });
+    } else {
+      response = await apiService.music.extractThumbnail({
+        key: sourceKey,
+        path: currentPath || '',
+      });
+    }
+
+    if (response.data?.success) {
+      try {
+        if (type === 'movie' && typeof movieState.fetchMovieFolders === 'function') {
+          await movieState.fetchMovieFolders(currentPath || '');
+        }
+        if (type === 'music' && typeof musicState.fetchMusicFolders === 'function') {
+          await musicState.fetchMusicFolders(currentPath || '');
+        }
+      } catch (refreshError) {
+        console.warn('Thumbnail refresh failed:', refreshError);
+      }
+
+      onSuccess?.(
+        response.data,
+        `${type} thumbnail extraction completed successfully`
+      );
+    } else {
+      onError?.(
+        response.data?.error ||
+          response.data?.message ||
+          'Thumbnail extraction failed'
+      );
+    }
+  } catch (error) {
+    console.error(`Thumbnail extraction error for ${type}:`, error);
+    onError?.(error.response?.data?.error || error.message || 'Network error occurred');
+  } finally {
+    setLoading(false);
+  }
+};
+
+/**
  * Get database operation labels based on content type
- * @param {string} type 
+ * @param {string} type
  * @returns {Object}
  */
 export const getDatabaseOperationLabels = (type) => {
@@ -236,7 +318,11 @@ export const getDatabaseOperationLabels = (type) => {
       reset: 'Reset DB Movie',
       scanDescription: 'Quét và cập nhật database movie',
       deleteDescription: 'Xóa tất cả dữ liệu movie từ database',
-      resetDescription: 'Xóa dữ liệu cũ và quét lại từ đầu'
+      resetDescription: 'Xóa dữ liệu cũ và quét lại từ đầu',
+      thumbnail: 'Quét thumbnail Movie',
+      thumbnailDescription: 'Tạo lại thumbnail cho toàn bộ video và thư mục con trong thư mục hiện tại.',
+      thumbnailSuccess: '✅ Đã quét thumbnail movie!',
+      thumbnailSuccessDetail: 'Đã hoàn tất quét thumbnail movie.'
     },
     music: {
       scan: 'Quét Music',
@@ -244,7 +330,11 @@ export const getDatabaseOperationLabels = (type) => {
       reset: 'Reset DB Music',
       scanDescription: 'Quét và cập nhật database music',
       deleteDescription: 'Xóa tất cả dữ liệu music từ database',
-      resetDescription: 'Xóa dữ liệu cũ và quét lại từ đầu'
+      resetDescription: 'Xóa dữ liệu cũ và quét lại từ đầu',
+      thumbnail: 'Quét thumbnail Music',
+      thumbnailDescription: 'Tạo lại thumbnail cho toàn bộ bài hát và thư mục con trong thư mục hiện tại.',
+      thumbnailSuccess: '✅ Đã quét thumbnail music!',
+      thumbnailSuccessDetail: 'Đã hoàn tất quét thumbnail music.'
     }
   };
   
@@ -257,5 +347,6 @@ export default {
   performDatabaseScan,
   performDatabaseDelete,
   performDatabaseReset,
+  performThumbnailExtraction,
   getDatabaseOperationLabels
 };


### PR DESCRIPTION
## Summary
- add a thumbnail extraction action to the sidebar admin tools for movie and music sources
- centralize thumbnail extraction logic with automatic folder refresh and fix the movie API path

## Testing
- npm run lint *(fails: ESLint config missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d42e72708332ac794aaaa3030f81