### PR TITLE
Limit offline caching to dedicated list page

### DIFF
--- a/react-app/public/offline/index.html
+++ b/react-app/public/offline/index.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Thư viện Offline</title>
+    <style>
+      /* 🧭 Offline list page is a tiny standalone UI, keep styling lightweight */
+      :root {
+        color-scheme: light dark;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: stretch;
+        padding: 24px;
+        background: linear-gradient(180deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.02));
+      }
+
+      .offline-wrapper {
+        width: min(900px, 100%);
+        background: rgba(255, 255, 255, 0.92);
+        border-radius: 18px;
+        padding: 32px 28px;
+        box-shadow: 0 22px 60px rgba(15, 23, 42, 0.1);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        backdrop-filter: blur(12px);
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: clamp(26px, 4vw, 36px);
+        color: #0ea5e9;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      h1 span {
+        font-size: clamp(28px, 5vw, 40px);
+      }
+
+      .sub-title {
+        margin: 0 0 24px;
+        color: #475569;
+        font-size: 16px;
+        line-height: 1.6;
+      }
+
+      .list-header,
+      .offline-item {
+        display: grid;
+        grid-template-columns: 1fr clamp(120px, 20vw, 160px) clamp(110px, 18vw, 150px);
+        align-items: center;
+        gap: 14px;
+      }
+
+      .list-header {
+        font-weight: 600;
+        font-size: 15px;
+        color: #334155;
+        padding: 10px 16px;
+        background: rgba(14, 165, 233, 0.1);
+        border-radius: 12px;
+        margin-bottom: 12px;
+      }
+
+      .offline-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .offline-item {
+        padding: 16px;
+        border-radius: 16px;
+        background: white;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 18px 30px rgba(15, 23, 42, 0.05);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .offline-item:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 24px 40px rgba(15, 23, 42, 0.08);
+      }
+
+      .offline-item strong {
+        display: block;
+        font-size: 16px;
+        color: #0f172a;
+        margin-bottom: 6px;
+      }
+
+      .offline-item span {
+        color: #64748b;
+        font-size: 14px;
+        display: block;
+      }
+
+      .meta {
+        color: #0f172a;
+        font-weight: 600;
+        font-size: 15px;
+        text-align: right;
+      }
+
+      .meta span {
+        display: block;
+        color: #64748b;
+        font-weight: 400;
+        font-size: 13px;
+      }
+
+      .empty-state {
+        border: 2px dashed rgba(148, 163, 184, 0.4);
+        padding: 40px 24px;
+        border-radius: 18px;
+        text-align: center;
+        color: #64748b;
+        font-size: 16px;
+      }
+
+      .actions {
+        margin-top: 32px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      button,
+      a.button-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border: none;
+        border-radius: 999px;
+        padding: 12px 20px;
+        font-size: 15px;
+        font-weight: 600;
+        cursor: pointer;
+        background: #0ea5e9;
+        color: white;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      button.secondary,
+      a.button-link.secondary {
+        background: rgba(15, 23, 42, 0.04);
+        color: #0f172a;
+      }
+
+      button:hover,
+      a.button-link:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 25px rgba(14, 165, 233, 0.2);
+      }
+
+      footer {
+        margin-top: 40px;
+        text-align: center;
+        font-size: 13px;
+        color: #94a3b8;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 16px;
+        }
+
+        .offline-wrapper {
+          padding: 24px 20px;
+        }
+
+        .list-header,
+        .offline-item {
+          grid-template-columns: 1fr;
+          text-align: left;
+        }
+
+        .meta {
+          text-align: left;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="offline-wrapper">
+      <h1><span>📚</span> Thư viện offline</h1>
+      <p class="sub-title">
+        Ứng dụng hiện không thể kết nối mạng. Dưới đây là danh sách chapter bạn đã tải
+        về thiết bị. Hãy mở lại khi trực tuyến để đồng bộ dữ liệu mới.
+      </p>
+
+      <section id="offline-content">
+        <div class="list-header">
+          <div>Nội dung đã lưu</div>
+          <div>Dung lượng</div>
+          <div>Tải ngày</div>
+        </div>
+        <div id="offline-list" class="offline-list" hidden></div>
+        <div id="empty-state" class="empty-state" hidden>
+          ❌ Chưa có chapter nào được lưu offline. Hãy tải trước khi mất kết nối.
+        </div>
+        <div id="error-state" class="empty-state" hidden>
+          ⚠️ Không thể đọc dữ liệu offline. Vui lòng mở lại ứng dụng khi trực tuyến.
+        </div>
+      </section>
+
+      <div class="actions">
+        <button id="refresh-button" type="button">🔄 Thử tải lại danh sách</button>
+        <a class="button-link secondary" href="/">⬅️ Quay về trang chủ</a>
+      </div>
+
+      <footer>
+        Dữ liệu được lưu trong thiết bị bằng IndexedDB. Bạn có thể xóa trong phần cài đặt của
+        trình duyệt để giải phóng dung lượng.
+      </footer>
+    </main>
+
+    <script>
+      // ⚙️ Cấu hình cơ sở dữ liệu giống với ứng dụng chính
+      const DB_NAME = 'offline-manga';
+      const STORE_NAME = 'chapters';
+      const DB_VERSION = 1;
+
+      const offlineList = document.getElementById('offline-list');
+      const emptyState = document.getElementById('empty-state');
+      const errorState = document.getElementById('error-state');
+      const refreshButton = document.getElementById('refresh-button');
+
+      /**
+       * 📦 Mở kết nối IndexedDB sử dụng cấu hình của ứng dụng
+       */
+      function openDatabase() {
+        return new Promise((resolve, reject) => {
+          const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+          request.onupgradeneeded = () => {
+            // Đảm bảo store tồn tại (phòng trường hợp người dùng chưa mở app chính)
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+              db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+          };
+
+          request.onerror = () => reject(request.error || new Error('Không thể mở cơ sở dữ liệu offline.'));
+          request.onsuccess = () => resolve(request.result);
+        });
+      }
+
+      /**
+       * 📚 Lấy toàn bộ chapter đã lưu offline
+       */
+      function loadOfflineChapters(db) {
+        return new Promise((resolve, reject) => {
+          const transaction = db.transaction(STORE_NAME, 'readonly');
+          const store = transaction.objectStore(STORE_NAME);
+          const request = store.getAll();
+
+          request.onerror = () => reject(request.error || new Error('Không thể đọc dữ liệu offline.'));
+          request.onsuccess = () => resolve(request.result || []);
+        });
+      }
+
+      /**
+       * 🧮 Định dạng dung lượng hiển thị thân thiện
+       */
+      function formatSize(bytes = 0) {
+        if (!bytes) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let index = 0;
+        let value = bytes;
+        while (value >= 1024 && index < units.length - 1) {
+          value /= 1024;
+          index += 1;
+        }
+        return `${value.toFixed(value < 10 && index > 0 ? 1 : 0)} ${units[index]}`;
+      }
+
+      /**
+       * 🗓️ Định dạng thời gian lưu chapter
+       */
+      function formatDate(timestamp) {
+        if (!timestamp) return 'Không rõ';
+        try {
+          return new Date(timestamp).toLocaleString('vi-VN');
+        } catch (error) {
+          return 'Không rõ';
+        }
+      }
+
+      /**
+       * 🧹 Hiển thị danh sách chapter hoặc empty state
+       */
+      function renderChapters(chapters) {
+        offlineList.innerHTML = '';
+
+        if (!chapters.length) {
+          offlineList.hidden = true;
+          emptyState.hidden = false;
+          errorState.hidden = true;
+          return;
+        }
+
+        const sorted = [...chapters].sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+
+        sorted.forEach((chapter) => {
+          const item = document.createElement('article');
+          item.className = 'offline-item';
+
+          const info = document.createElement('div');
+          info.innerHTML = `
+            <strong>${chapter.mangaTitle || 'Unknown manga'}</strong>
+            <span>${chapter.chapterTitle || chapter.id}</span>
+          `;
+
+          const size = document.createElement('div');
+          size.className = 'meta';
+          size.innerHTML = `
+            ${formatSize(chapter.bytes)}
+            <span>${chapter.totalPages || 0} trang</span>
+          `;
+
+          const date = document.createElement('div');
+          date.className = 'meta';
+          date.innerHTML = `
+            ${formatDate(chapter.updatedAt || chapter.createdAt)}
+            <span>Mã chương: ${chapter.id}</span>
+          `;
+
+          item.appendChild(info);
+          item.appendChild(size);
+          item.appendChild(date);
+
+          offlineList.appendChild(item);
+        });
+
+        offlineList.hidden = false;
+        emptyState.hidden = true;
+        errorState.hidden = true;
+      }
+
+      /**
+       * 🔁 Luồng tải dữ liệu offline hoàn chỉnh
+       */
+      async function loadOfflineLibrary() {
+        try {
+          refreshButton.disabled = true;
+          const db = await openDatabase();
+          const chapters = await loadOfflineChapters(db);
+          renderChapters(chapters);
+        } catch (error) {
+          console.error('[Offline List] Failed to load offline data:', error);
+          offlineList.hidden = true;
+          emptyState.hidden = true;
+          errorState.hidden = false;
+        } finally {
+          refreshButton.disabled = false;
+        }
+      }
+
+      refreshButton.addEventListener('click', () => {
+        loadOfflineLibrary();
+      });
+
+      // 🚀 Auto load ngay khi trang mở
+      loadOfflineLibrary();
+    </script>
+  </body>
+</html>

--- a/react-app/src/utils/serviceWorkerManager.js
+++ b/react-app/src/utils/serviceWorkerManager.js
@@ -164,16 +164,19 @@ class ServiceWorkerManager {
     try {
       const cacheInfo = await this.getCacheInfo();
       const caches = cacheInfo?.caches || {};
-      
-      // Since offline.html is removed, check if we have React app cache for offline support
-      const staticCache = caches['offline-core'];
-      const dynamicCache = caches['reader-dynamic'];
-      const hasOfflineFallback = (staticCache?.count || 0) > 0 || (dynamicCache?.count || 0) > 0;
-      const hasChapterImages = (caches['chapter-images']?.count || 0) > 0;
+
+      // Find caches by type instead of exact name (names contain version suffixes)
+      const cacheEntries = Object.entries(caches);
+      const offlineCoreEntry = cacheEntries.find(([, data]) => data.type === 'offline-core');
+      const dynamicEntry = cacheEntries.find(([, data]) => data.type === 'dynamic');
+      const imageEntry = cacheEntries.find(([name, data]) => data.type === 'images' || name.includes('chapter-images'));
+
+      const hasOfflineFallback = Boolean((offlineCoreEntry?.[1]?.count || 0) > 0 || (dynamicEntry?.[1]?.count || 0) > 0);
+      const hasChapterImages = Boolean((imageEntry?.[1]?.count || 0) > 0);
 
       return {
         capable: hasOfflineFallback,
-        reason: hasOfflineFallback ? 'Offline fallback cached' : 'Offline fallback missing',
+        reason: hasOfflineFallback ? 'Offline list cached' : 'Offline fallback missing',
         cacheInfo,
         offlineStatus: {
           hasOfflineFallback,


### PR DESCRIPTION
## Summary
- add a standalone `/offline/index.html` page that renders the stored chapter list from IndexedDB for offline mode
- update the service worker to precache only the new offline list page, drop thumbnail precaching, and use it as the navigation fallback
- adjust the service worker manager to detect offline readiness by cache type instead of exact cache names

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d12e4341608332ab9c7258dacce253